### PR TITLE
New tests and new principle for `iterate_subcorpora()`

### DIFF
--- a/new_tests/test_extract.py
+++ b/new_tests/test_extract.py
@@ -18,19 +18,19 @@ def collect_test_name(request):
 
 class TestNameCollection():
 
-    def test_collect_parse_obj_names(self, parse_obj, collect_test_name):
-        """Run this if the parametrization of Parse has changed and you need to update TEST_NAMES."""
-        print('\ntest_names = [')
-        for name in sorted(TEST_NAMES['test_collect_parse_obj_names']):
-            print(f" '{name}',")
-        print("]")
+    # def test_collect_parse_obj_names(self, parse_obj, collect_test_name):
+    #     """Run this if the parametrization of Parse has changed and you need to update TEST_NAMES."""
+    #     print('\ntest_names = [')
+    #     for name in sorted(TEST_NAMES['test_collect_parse_obj_names']):
+    #         print(f" '{name}',")
+    #     print("]")
 
     def test_collect_parsed_parse_obj_names(self, parsed_parse_obj, collect_test_name):
         """Run this if the parametrization of Parse has changed and you need to update TEST_NAMES."""
-        print('\nname2expected = {')
+        print('\nname2expected.update(dict(')
         for name in sorted(TEST_NAMES['test_collect_parsed_parse_obj_names']):
-            print(f" '{name}'" + ": {},")
-        print("}")
+            print(f"\t{name}" + " = {},")
+        print("))")
 
 
 ################################## Actual tests ############################################
@@ -40,59 +40,21 @@ class TestNameCollection():
 @pytest.mark.usefixtures("parse_objects")
 class TestEmptyParse():
 
-    test_names = [
-        'multiple-all_paths',
-        'multiple-directory',
-        'multiple-directory+paths',
-        'multiple-mscx_paths',
-        'multiple-tsv_paths',
-        'single-all_paths',
-        'single-directory',
-        'single-directory+paths',
-        'single-mscx_paths',
-        'single-tsv_paths',
-    ]
-
     @pytest.fixture()
     def expected_keys(self, request):
-        expected = [
-            {'mixed_files': {'.mscx': 8,  # multiple-all_paths
-                             '.mscz': 1,
-                             '.musicxml': 1,
-                             '.mxl': 1,
-                             '.tsv': 1,
-                             '.xml': 1},
-             'ravel_piano': {'.mscx': 5, '.tsv': 14},
-             'sweelinck_keyboard': {'.mscx': 1, '.tsv': 4},
-             'wagner_overtures': {'.mscx': 2, '.tsv': 7}},
-            {'mixed_files': {'.mscx': 8, '.mscz': 1, '.tsv': 1},  # multiple-directory
-             'ravel_piano': {'.mscx': 5, '.tsv': 14},
-             'sweelinck_keyboard': {'.mscx': 1, '.tsv': 4},
-             'wagner_overtures': {'.mscx': 2, '.tsv': 7}},
-            {'mixed_files': {'.mscx': 8,  # multiple-directory+paths
-                             '.mscz': 1,
-                             '.musicxml': 1,
-                             '.mxl': 1,
-                             '.tsv': 1,
-                             '.xml': 1},
-             'ravel_piano': {'.mscx': 5, '.tsv': 14},
-             'sweelinck_keyboard': {'.mscx': 1, '.tsv': 4},
-             'wagner_overtures': {'.mscx': 2, '.tsv': 7}},
-            {'mixed_files': {'.mscx': 8},  # multiple-mscx_paths
-             'ravel_piano': {'.mscx': 5},
-             'sweelinck_keyboard': {'.mscx': 1},
-             'wagner_overtures': {'.mscx': 2}},
-            {'mixed_files': {'.tsv': 1},  # multiple-tsv_paths
-             'ravel_piano': {'.tsv': 14},
-             'sweelinck_keyboard': {'.tsv': 4},
-             'wagner_overtures': {'.tsv': 7}},
-            {'pleyel_quartets': {'.mscx': 6, '.tsv': 13}},  # single-all_paths
-            {'pleyel_quartets': {'.mscx': 6, '.tsv': 13}},  # single-directory
-            {'pleyel_quartets': {'.mscx': 6, '.tsv': 13}},  # single-directory+paths
-            {'pleyel_quartets': {'.mscx': 6}},  # single-mscx_paths
-            {'pleyel_quartets': {'.tsv': 13}},  # single-tsv_paths
-        ]
-        name2expected = dict(zip(self.test_names, expected))
+        name2expected = defaultdict(dict)
+        name2expected.update(dict(
+            everything = {'mixed_files': {'.mscx': 8, '.mscz': 1},
+                         'outputs': {'.tsv': 3},
+                         'ravel_piano': {'.mscx': 5, '.tsv': 14},
+                         'sweelinck_keyboard': {'.mscx': 1, '.tsv': 4},
+                         'wagner_overtures': {'.mscx': 2, '.tsv': 7}},
+            regular_dirs = {'mixed_files': {'.mscx': 8, '.mscz': 1},
+                             'outputs': {'.tsv': 3},
+                             'ravel_piano': {'.mscx': 5, '.tsv': 14},
+                             'sweelinck_keyboard': {'.mscx': 1, '.tsv': 4},
+                             'wagner_overtures': {'.mscx': 2, '.tsv': 7}},
+        ))
         name = node_name2cfg_name(request.node.name)
         return name2expected[name]
 
@@ -110,39 +72,23 @@ class TestParsedParse():
 
     @pytest.fixture()
     def expected_keys(self, request):
-        name2expected = {
-            'parsed_all-multiple-all_paths': {},
-            'parsed_all-multiple-directory': {},
-            'parsed_all-multiple-directory+paths': {},
-            'parsed_all-multiple-mscx_paths': {},
-            'parsed_all-multiple-tsv_paths': {},
-            'parsed_all-single-all_paths': {},
-            'parsed_all-single-directory': {},
-            'parsed_all-single-directory+paths': {},
-            'parsed_all-single-mscx_paths': {},
-            'parsed_all-single-tsv_paths': {},
-            'parsed_mscx-multiple-all_paths': {},
-            'parsed_mscx-multiple-directory': {},
-            'parsed_mscx-multiple-directory+paths': {},
-            'parsed_mscx-multiple-mscx_paths': {},
-            'parsed_mscx-multiple-tsv_paths': {},
-            'parsed_mscx-single-all_paths': {},
-            'parsed_mscx-single-directory': {},
-            'parsed_mscx-single-directory+paths': {},
-            'parsed_mscx-single-mscx_paths': {'pleyel_quartets': {'.mscx': 6}},
-            'parsed_mscx-single-tsv_paths': {},
-            'parsed_tsv-multiple-all_paths': {},
-            'parsed_tsv-multiple-directory': {},
-            'parsed_tsv-multiple-directory+paths': {},
-            'parsed_tsv-multiple-mscx_paths': {},
-            'parsed_tsv-multiple-tsv_paths': {},
-            'parsed_tsv-single-all_paths': {},
-            'parsed_tsv-single-directory': {},
-            'parsed_tsv-single-directory+paths': {},
-            'parsed_tsv-single-mscx_paths': {},
-            'parsed_tsv-single-tsv_paths': {},
-        }
-        #name2expected = dict(zip_longest(self.test_names, expected, fillvalue={}))
+        name2expected = defaultdict(dict)
+        name2expected.update(dict(
+            parsed_mscx-regular_dirs = {'ravel_piano': {'.mscx': 5, '.tsv': 14},
+E          'sweelinck_keyboard': {'.mscx': 1, '.tsv': 4},
+E          'wagner_overtures': {'.mscx': 2, '.tsv': 7}},
+
+            everything={'mixed_files': {'.mscx': 8, '.mscz': 1},
+                       'outputs': {'.tsv': 3},
+                       'ravel_piano': {'.mscx': 5, '.tsv': 14},
+                       'sweelinck_keyboard': {'.mscx': 1, '.tsv': 4},
+                       'wagner_overtures': {'.mscx': 2, '.tsv': 7}},
+            regular_dirs={'mixed_files': {'.mscx': 8, '.mscz': 1},
+                            'outputs': {'.tsv': 3},
+                            'ravel_piano': {'.mscx': 5, '.tsv': 14},
+                            'sweelinck_keyboard': {'.mscx': 1, '.tsv': 4},
+                            'wagner_overtures': {'.mscx': 2, '.tsv': 7}},
+        ))
         name = node_name2cfg_name(request.node.name)
         return name2expected[name]
 

--- a/new_tests/test_extract.py
+++ b/new_tests/test_extract.py
@@ -116,6 +116,11 @@ class TestParsedParse():
     def test_keys(self, expected_keys):
         assert self.parsed_parse_obj.count_extensions(per_key=True) == expected_keys
 
+    def test_check(self, caplog):
+        _ = self.parsed_parse_obj.get_dataframes(expanded=True)
+        for record in caplog.records:
+            if record.levelname == 'WARNING':
+                print(inspect_object(record))
 
 # add_dir (different keys)
 # file_re

--- a/src/ms3/transformations.py
+++ b/src/ms3/transformations.py
@@ -76,10 +76,10 @@ def add_quarterbeats_col(df, offset_dict, interval_index=False):
     else:
         logger.debug("quarterbeats column was already present.")
     if interval_index and all(c in df.columns for c in ('quarterbeats', 'duration_qb')):
-        df = replace_index_by_intervals(df)
+        df = replace_index_by_intervals(df, logger=logger)
     return df
 
-
+@function_logger
 def add_weighted_grace_durations(notes, weight=1/2):
     """ For a given notes table, change the 'duration' value of all grace notes, weighting it by ``weight``.
 
@@ -109,7 +109,7 @@ def add_weighted_grace_durations(notes, weight=1/2):
     if 'duration_qb' in notes.columns:
         notes.loc[grace, 'duration_qb'] = (new_durations * 4).astype(float)
         if isinstance(notes.index, pd.IntervalIndex):
-            notes = replace_index_by_intervals(notes)
+            notes = replace_index_by_intervals(notes, logger=logger)
     return notes
 
 


### PR DESCRIPTION
This slim design replaces the previous, slighly convoluted computation of configurations and, at the same time, prepares for adding more selected and particular cases using different parametrizations of Parse objects. Currenly, only `Parse.add_dir()` is used, which is why the problematic cases with using `Parse.add_files()` do not occur: There, `metadata.tsv` and `IGNORED_WARNINGS` files will have to be detected even if not specified as one of the `[paths]`, due to the new interface that relies heavily on `metadata.tsv`.

To run the tests, clone it into your user directory `~` and check out the branch `ms3_tests`. Then, in your ms3 environment, `pip install pytest-cov`. Afterwards you should be able to run the tests in the file new_tests/test_extract.py. Note that pytest automatically uses all fixtures from the file `conftest.py`.