### PR TITLE
Low-level method for creating a score excerpt

### DIFF
--- a/src/ms3/bs4_measures.py
+++ b/src/ms3/bs4_measures.py
@@ -822,7 +822,7 @@ class MeasureList(LoggedClass):
 
 
 class NextColumnMaker(LoggedClass):
-    def __init__(self, df, volta_structure, sections=True, logger_cfg={}):
+    def __init__(self, df, volta_structure, sections=True, logger_cfg=None):
         super().__init__(subclass="NextColumnMaker", logger_cfg=logger_cfg)
         self.sections = sections
         self.mc = df.mc  # Series

--- a/src/ms3/bs4_parser.py
+++ b/src/ms3/bs4_parser.py
@@ -2674,15 +2674,7 @@ but the keys of _MSCX_bs4.tags[{mc}][{staff}] are {dict_keys}."""
         self.metadata = self._get_metadata()
 
     def write_score_to_handler(self, file_handler: IO) -> bool:
-        try:
-            mscx_string = bs4_to_mscx(self.soup)
-        except Exception as e:
-            self.logger.error(
-                f"Couldn't output score because of the following error:\n{e}"
-            )
-            return False
-        file_handler.write(mscx_string)
-        return True
+        return write_score_to_handler(self.soup, file_handler, logger=self.logger)
 
     def __getstate__(self):
         """When pickling, make object read-only, i.e. delete the BeautifulSoup object and all references to tags."""
@@ -3653,12 +3645,28 @@ def format_node(node, indent):
     return f"{space}{make_oneliner(node)}\n"
 
 
-def bs4_to_mscx(soup):
+def bs4_to_mscx(soup: bs4.BeautifulSoup):
     """Turn the BeautifulSoup into a string representing an MSCX file"""
     assert soup is not None, "BeautifulSoup XML structure is None"
     initial_tag = """<?xml version="1.0" encoding="UTF-8"?>\n"""
     first_tag = soup.find()
     return initial_tag + format_node(first_tag, indent=0)
+
+
+def write_score_to_handler(
+    soup: bs4.BeautifulSoup,
+    file_handler: IO,
+    logger=None,
+) -> bool:
+    if logger is None:
+        logger = module_logger
+    try:
+        mscx_string = bs4_to_mscx(soup)
+    except Exception as e:
+        logger.error(f"Couldn't output score because of the following error:\n{e}")
+        return False
+    file_handler.write(mscx_string)
+    return True
 
 
 # endregion Functions for writing BeautifulSoup to MSCX file

--- a/src/ms3/bs4_parser.py
+++ b/src/ms3/bs4_parser.py
@@ -92,7 +92,6 @@ from typing import (
     Collection,
     Dict,
     Hashable,
-    Iterable,
     Iterator,
     List,
     Literal,
@@ -1786,9 +1785,10 @@ and {loc_after} before the subsequent {nxt_name}."""
             remember.append(dict(name="location", duration=loc_after, tag=location))
         return remember
 
+    @cache
     def make_excerpt(
         self,
-        included_mcs: Iterable[int] | int,
+        included_mcs: Tuple[int] | int,
         globalkey: Optional[str] = None,
         localkey: Optional[str] = None,
     ) -> Excerpt:

--- a/src/ms3/logger.py
+++ b/src/ms3/logger.py
@@ -3,7 +3,7 @@ import os
 import sys
 from contextlib import contextmanager
 from enum import Enum, unique
-from typing import Iterable, List, Set, Tuple
+from typing import Iterable, List, Optional, Set, Tuple
 
 LEVELS = {
     "DEBUG": logging.DEBUG,
@@ -115,7 +115,9 @@ class LoggedClass:
     _deprecated_elements: List[str] = []
     """Methods and properties named here will be removed from the object's tab completion."""
 
-    def __init__(self, subclass, logger_cfg={}):
+    def __init__(self, subclass: str, logger_cfg: Optional[dict] = None):
+        if logger_cfg is None:
+            logger_cfg = {}
         old_code_warnings = []
         if "logger_cfg" in logger_cfg:
             old_code_warnings.append("logger_cfg")

--- a/src/ms3/operations.py
+++ b/src/ms3/operations.py
@@ -700,20 +700,27 @@ def make_coloring_reports_and_warnings(
                 if message_id in ignored_warning_ids:
                     continue
                 test_passes = False
-                if len(t.added_tones) > 0:
-                    added = (
-                        f" plus the added {tpc2scale_degree(t.added_tones, t.localkey, t.globalkey)} ["
-                        f"{fifths2name(t.added_tones)}]"
-                    )
+                if pd.isnull(t.localkey) or pd.isnull(t.globalkey):
+                    context_msg = "The local and/or global key could not be determined."
                 else:
-                    added = ""
-                msg = f"""The label '{t.label}' in m. {t.mn}, onset {t.mn_onset} (MC {t.mc}, onset {t.mc_onset})
-                seems not to correspond well to the score (which does not necessarily mean it is wrong).
-In the context of {t.globalkey}.{t.localkey}, it expresses the scale degrees
+                    if len(t.added_tones) > 0:
+                        added = (
+                            f" plus the added {tpc2scale_degree(t.added_tones, t.localkey, t.globalkey)} ["
+                            f"{fifths2name(t.added_tones)}]"
+                        )
+                    else:
+                        added = ""
+                    context_msg = f"""In the context of {t.globalkey}.{t.localkey}, it expresses the scale degrees
 {tpc2scale_degree(t.chord_tones, t.localkey, t.globalkey)} [{fifths2name(t.chord_tones)}]{added}.
 The corresponding score segment has {t.n_untouched} within-label and {t.n_colored} out-of-label note onsets,
 a ratio of {t.count_ratio} > {threshold} (the current, arbitrary, threshold).
 If it turns out the label is correct, please add the header of this warning to the IGNORED_WARNINGS, ideally followed
 by a free-text comment in subsequent lines starting with a space or tab."""
-                piece_logger.warning(msg, extra={"message_id": message_id})
+                msg = (
+                    f"The label '{t.label}' in m. {t.mn}, onset {t.mn_onset} (MC {t.mc}, onset {t.mc_onset}) seems "
+                    f"not to correspond well to the score (which does not necessarily mean it is wrong).\n"
+                )
+                piece_logger.warning(
+                    msg + context_msg, extra={"message_id": message_id}
+                )
     return test_passes

--- a/src/ms3/score.py
+++ b/src/ms3/score.py
@@ -1018,7 +1018,7 @@ class MSCX(LoggedClass):
         implemented_parsers = ["bs4"]
         if self.parser in implemented_parsers:
             try:
-                self._parsed = _MSCX_bs4(
+                self._parsed = _MSCX_bs4.from_filepath(
                     self.mscx_src, read_only=self.read_only, logger_cfg=self.logger_cfg
                 )
             except Exception:


### PR DESCRIPTION
This PR addresses the base requirement for #89 which is the excerpt creation engine.

This is achieved by subclassing `_MSCX_bs4`, bringing forth an `Excerpt` class that uses its parents XML manipulation methods (especially `.new_tag`) to amend the beginning of the excerpt so that it displays the correct

* measure number
* time signature
* key signature
* clefs

and, if annotations are present but no label occurs on quarterbeat `0` of the excerpt, that it repeats the label in vigor at that moment. Furthermore, the new method `.make_excerpt()` comes with the arguments `globalkey` and `localkey` which allow for updating/completing this information for the first label.

One thing that is currently missing is the repetition of the tempo mark in vigor. A simple solution (rather than, say, finding the performance indication and printing it in parentheses) would be to use the tempo from the previous marking and simply include it as an invisible metronome mark.