### PR TITLE
Updated schema mechanism following the first trial

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "frictionless_schemas"]
+	path = frictionless_schemas
+	url = https://github.com/DCMLab/frictionless_schemas

--- a/src/ms3/bs4_parser.py
+++ b/src/ms3/bs4_parser.py
@@ -2382,6 +2382,8 @@ but the keys of _MSCX_bs4.tags[{mc}][{staff}] are {dict_keys}."""
           DataFrame representing the :ref:`rests` of the MuseScore file.
         """
         rests = self.rl()
+        if len(rests) == 0:
+            return None
         if unfold:
             rests = self.unfold_facet_df(rests, "rests")
             if rests is None:
@@ -2815,7 +2817,7 @@ but the keys of _MSCX_bs4.tags[{mc}][{staff}] are {dict_keys}."""
             metronome_mark_missing = False
         # here we could insert logic for treating incipit measure groups differently
         if metronome_mark_missing:
-            msg = "No metronome mark found in the very first measure"
+            msg = "No metronome mark found in the first measure"
             tempo_selector = (events.event == "Tempo").fillna(False)
             if tempo_selector.sum() == 0:
                 msg += " nor anywhere else in the score."

--- a/src/ms3/bs4_parser.py
+++ b/src/ms3/bs4_parser.py
@@ -2389,6 +2389,10 @@ but the keys of _MSCX_bs4.tags[{mc}][{staff}] are {dict_keys}."""
         return self._rl
 
     def parse_soup(self):
+        """First step of parsing the MuseScore source. Involves discovering the <staff> tags and storing the
+        <Measure> tags of each in the :attr:`measure_nodes` dictionary.  Also stores the drum_map for each Drumset
+        staff.
+        """
         if self.version[0] not in ("3", "4"):
             # self.logger.exception(f"Cannot parse MuseScore {self.version} file.")
             raise ValueError(

--- a/src/ms3/bs4_parser.py
+++ b/src/ms3/bs4_parser.py
@@ -740,7 +740,8 @@ and {loc_after} before the subsequent {nxt_name}."""
                 return
         chords = add_quarterbeats_col(
             chords,
-            self.offset_dict(unfold=unfold),
+            offset_dict=self.offset_dict(unfold=unfold),
+            offset_dict_all_endings=self.offset_dict(all_endings=True),
             interval_index=interval_index,
             logger=self.logger,
         )
@@ -1112,7 +1113,8 @@ and {loc_after} before the subsequent {nxt_name}."""
                 return
         events = add_quarterbeats_col(
             events,
-            self.offset_dict(unfold=unfold),
+            offset_dict=self.offset_dict(unfold=unfold),
+            offset_dict_all_endings=self.offset_dict(all_endings=True),
             interval_index=interval_index,
             logger=self.logger,
         )
@@ -1155,7 +1157,8 @@ and {loc_after} before the subsequent {nxt_name}."""
                 return
         form = add_quarterbeats_col(
             form,
-            self.offset_dict(unfold=unfold),
+            offset_dict=self.offset_dict(unfold=unfold),
+            offset_dict_all_endings=self.offset_dict(all_endings=True),
             interval_index=interval_index,
             logger=self.logger,
         )
@@ -2252,7 +2255,8 @@ and {loc_after} before the subsequent {nxt_name}."""
                 return
         notes = add_quarterbeats_col(
             notes,
-            self.offset_dict(unfold=unfold),
+            offset_dict=self.offset_dict(unfold=unfold),
+            offset_dict_all_endings=self.offset_dict(all_endings=True),
             interval_index=interval_index,
             logger=self.logger,
         )
@@ -2288,7 +2292,8 @@ and {loc_after} before the subsequent {nxt_name}."""
                 return
         nrl = add_quarterbeats_col(
             nrl,
-            self.offset_dict(unfold=unfold),
+            offset_dict=self.offset_dict(unfold=unfold),
+            offset_dict_all_endings=self.offset_dict(all_endings=True),
             interval_index=interval_index,
             logger=self.logger,
         )
@@ -2380,7 +2385,8 @@ but the keys of _MSCX_bs4.tags[{mc}][{staff}] are {dict_keys}."""
                 return
         rests = add_quarterbeats_col(
             rests,
-            self.offset_dict(unfold=unfold),
+            offset_dict=self.offset_dict(unfold=unfold),
+            offset_dict_all_endings=self.offset_dict(all_endings=True),
             interval_index=interval_index,
             logger=self.logger,
         )

--- a/src/ms3/bs4_parser.py
+++ b/src/ms3/bs4_parser.py
@@ -2312,14 +2312,22 @@ and {loc_after} before the subsequent {nxt_name}."""
         self,
         all_endings: bool = False,
         unfold: bool = False,
-        negative_anacrusis: bool = False,
     ) -> dict:
         """Dictionary mapping MCs (measure counts) to their quarterbeat offset from the piece's beginning.
         Used for computing quarterbeats for other facets.
 
         Args:
-          all_endings: Uses the column 'quarterbeats_all_endings' of the measures table if it has one, otherwise
-              falls back to the default 'quarterbeats'.
+          all_endings:
+              If a pieces as alternative endings, by default, only the second ending is taken into account for
+              computing quarterbeats in order to make the timeline correspond to a rendition without performing
+              repeats. Events in other endings, notably the first, receive value NA so that they can be filtered out.
+              For score addressability, one might want to apply a continuous timeline to all measures, in which case
+              one would pass True to use the column 'quarterbeats_all_endings' of the measures table if it has one.
+              If not, falls back to the default 'quarterbeats'.
+          unfold:
+              Pass True to compute quarterbeats for a mc_playthrough column resulting from unfolding repeats.
+              The parameter ``all_endings`` is ignored in this case because the unfolded version brings each ending in
+              its correct place.
 
         Returns:
           {MC -> quarterbeat_offset}. Offsets are Fractions. If ``all_endings`` is not set to ``True``,
@@ -2328,7 +2336,7 @@ and {loc_after} before the subsequent {nxt_name}."""
         measures = self.measures(unfold=unfold)
         if unfold:
             offset_dict = make_continuous_offset_series(
-                measures, negative_anacrusis=negative_anacrusis
+                measures,
             ).to_dict()
         else:
             offset_dict = make_offset_dict_from_measures(measures, all_endings)

--- a/src/ms3/bs4_parser.py
+++ b/src/ms3/bs4_parser.py
@@ -37,7 +37,7 @@
 .. |mc_onset| replace:: :ref:`mc_onset <mc_onset>`
 .. |metronome_base| replace:: :ref:`metronome_base <metronome_base>`
 .. |metronome_number| replace:: :ref:`metronome_number <metronome_number>`
-.. |metronome_visible| replace:: :ref:`metronome_visible <metronome_visible>`
+.. |tempo_visible| replace:: :ref:`tempo_visible <tempo_visible>`
 .. |midi| replace:: :ref:`midi <midi>`
 .. |mn| replace:: :ref:`mn <mn>`
 .. |mn_onset| replace:: :ref:`mn_onset <mn_onset>`
@@ -714,7 +714,7 @@ and {loc_after} before the subsequent {nxt_name}."""
         |voice|, |duration|, |gracenote|, |tremolo|, |nominal_duration|, |scalar|, |volta|, |chord_id|, |dynamics|,
         |articulation|, |staff_text|, |slur|, |Ottava:8va|, |Ottava:8vb|, |pedal|, |TextLine|, |decrescendo_hairpin|,
         |diminuendo_line|, |crescendo_line|, |crescendo_hairpin|, |tempo|, |qpm|, |metronome_base|, |metronome_number|,
-        |metronome_visible|, |lyrics:1|, |Ottava:15mb|
+        |tempo_visible|, |lyrics:1|, |Ottava:15mb|
 
         Args:
           mode:
@@ -1385,7 +1385,7 @@ and {loc_after} before the subsequent {nxt_name}."""
                     "qpm",
                     "metronome_base",
                     "metronome_number",
-                    "metronome_visible",
+                    "tempo_visible",
                 ]
             )
         if params["thoroughbass"]:
@@ -2707,14 +2707,10 @@ but the keys of _MSCX_bs4.tags[{mc}][{staff}] are {dict_keys}."""
                                             "metronome_number", float(value)
                                         )
                                     try:
-                                        metronome_visible = int(
-                                            tempo_tag.visible.string
-                                        )
+                                        tempo_visible = int(tempo_tag.visible.string)
                                     except AttributeError:
-                                        metronome_visible = 1
-                                    safe_update_event(
-                                        "metronome_visible", metronome_visible
-                                    )
+                                        tempo_visible = 1
+                                    safe_update_event("tempo_visible", tempo_visible)
                                 elif parent_name == "Lyrics":
                                     lyrics_tag = text_tag.parent
                                     no_tag = lyrics_tag.find("no")

--- a/src/ms3/bs4_parser.py
+++ b/src/ms3/bs4_parser.py
@@ -1414,7 +1414,10 @@ and {loc_after} before the subsequent {nxt_name}."""
             additional_cols.extend(
                 [c for c in df.columns if feature in c and c not in main_cols]
             )
-        return df[main_cols + additional_cols]
+        result = df[main_cols + additional_cols]
+        if mode == "auto":
+            return result.dropna(axis=1, how="all")
+        return result.copy()
 
     @cache
     def get_playthrough_mcs(self) -> Optional[pd.Series]:

--- a/src/ms3/corpus.py
+++ b/src/ms3/corpus.py
@@ -3140,13 +3140,14 @@ class Corpus(LoggedClass):
                                 f"Would have stored the {facet} from {file.rel_path} as {file_path}."
                             )
                         else:
+                            create_descriptor = frictionless and facet != "events"
                             descriptor_or_resource_path = store_dataframe_resource(
                                 df=df,
                                 directory=directory,
                                 piece_name=piece_name,
                                 facet=facet_param,
                                 zipped=False,
-                                frictionless=frictionless,
+                                frictionless=create_descriptor,
                                 raise_exception=False,
                                 write_or_remove_errors_file=True,
                                 logger=self.logger,

--- a/src/ms3/piece.py
+++ b/src/ms3/piece.py
@@ -1,22 +1,65 @@
 import os
 import re
-from collections import defaultdict, Counter
-from typing import Dict, Literal, Union, Iterator, Optional, overload, List, Tuple
+from collections import Counter, defaultdict
+from typing import Dict, Iterator, List, Literal, Optional, Tuple, Union, overload
 
 import pandas as pd
 
+from ._typing import (
+    AnnotationsFacet,
+    DataframeDict,
+    Facet,
+    FacetArguments,
+    Facets,
+    FileDataframeTuple,
+    FileDataframeTupleMaybe,
+    FileDict,
+    FileList,
+    FileParsedTuple,
+    FileParsedTupleMaybe,
+    FileScoreTuple,
+    FileScoreTupleMaybe,
+    ParsedFile,
+    ScoreFacet,
+    ScoreFacets,
+    TSVtype,
+    TSVtypes,
+)
 from .annotations import Annotations
-from ._typing import FileList, ParsedFile, FileDict, Facet, TSVtype, Facets, ScoreFacets, ScoreFacet, FileParsedTuple, FacetArguments, FileScoreTuple, \
-    FileDataframeTupleMaybe, DataframeDict, FileDataframeTuple, TSVtypes, FileScoreTupleMaybe, FileParsedTupleMaybe, AnnotationsFacet
-from .transformations import dfs2quarterbeats
-from .utils import File, infer_tsv_type, automatically_choose_from_disambiguated_files, ask_user_to_choose_from_disambiguated_files, \
-    files2disambiguation_dict, get_musescore, load_tsv, metadata2series, pretty_dict, resolve_facets_param, \
-    available_views2str, argument_and_literal_type2list, check_argument_against_literal_type, make_file_path, write_tsv, assert_dfs_equal, \
-    parse_tsv_file_at_git_revision, disambiguate_files, replace_index_by_intervals, update_labels_cfg, compute_path_from_file, store_dataframe_resource
-from .utils.constants import AUTOMATIC_COLUMNS, MUSESCORE_HEADER_FIELDS, MUSESCORE_METADATA_FIELDS, LEGACY_COLUMNS
-from .score import Score
 from .logger import LoggedClass
-from .view import View, DefaultView
+from .score import Score
+from .transformations import dfs2quarterbeats
+from .utils import (
+    File,
+    argument_and_literal_type2list,
+    ask_user_to_choose_from_disambiguated_files,
+    assert_dfs_equal,
+    automatically_choose_from_disambiguated_files,
+    available_views2str,
+    check_argument_against_literal_type,
+    compute_path_from_file,
+    disambiguate_files,
+    files2disambiguation_dict,
+    get_musescore,
+    infer_tsv_type,
+    load_tsv,
+    make_file_path,
+    metadata2series,
+    parse_tsv_file_at_git_revision,
+    pretty_dict,
+    replace_index_by_intervals,
+    resolve_facets_param,
+    store_dataframe_resource,
+    update_labels_cfg,
+    write_tsv,
+)
+from .utils.constants import (
+    AUTOMATIC_COLUMNS,
+    LEGACY_COLUMNS,
+    MUSESCORE_HEADER_FIELDS,
+    MUSESCORE_METADATA_FIELDS,
+)
+from .view import DefaultView, View
 
 
 class Piece(LoggedClass):
@@ -24,10 +67,12 @@ class Piece(LoggedClass):
 
     _deprecated_elements = ["get_dataframe"]
 
-    def __init__(self, pname: str, view: View = None, labels_cfg={}, ms=None, **logger_cfg):
-        super().__init__(subclass='Piece', logger_cfg=logger_cfg)
+    def __init__(
+        self, pname: str, view: View = None, labels_cfg={}, ms=None, **logger_cfg
+    ):
+        super().__init__(subclass="Piece", logger_cfg=logger_cfg)
         self.name = pname
-        available_types = ('scores',) + Score.dataframe_types
+        available_types = ("scores",) + Score.dataframe_types
         self.facet2files: Dict[str, FileList] = defaultdict(list)
         """{typ -> [:obj:`File`]} dict storing file information for associated types.
         """
@@ -54,9 +99,11 @@ class Piece(LoggedClass):
             self._views[None] = DefaultView(level=self.logger.getEffectiveLevel())
         else:
             self._views[None] = view
-            if view.name != 'default':
-                self._views['default'] = DefaultView(level=self.logger.getEffectiveLevel())
-        self._views['all'] = View(level=self.logger.getEffectiveLevel())
+            if view.name != "default":
+                self._views["default"] = DefaultView(
+                    level=self.logger.getEffectiveLevel()
+                )
+        self._views["all"] = View(level=self.logger.getEffectiveLevel())
         self._ms = get_musescore(ms, logger=self.logger)
         """:obj:`str`
         Path or command of the local MuseScore 3 installation if specified by the user."""
@@ -66,13 +113,13 @@ class Piece(LoggedClass):
         """
 
         self.labels_cfg = {
-            'staff': None,
-            'voice': None,
-            'harmony_layer': None,
-            'positioning': False,
-            'decode': True,
-            'column_name': 'label',
-            'color_format': None,
+            "staff": None,
+            "voice": None,
+            "harmony_layer": None,
+            "positioning": False,
+            "decode": True,
+            "column_name": "label",
+            "color_format": None,
         }
         """:obj:`dict`
         Configuration dictionary to determine the output format of :py:attr:`~.score.Score.labels` and
@@ -80,9 +127,10 @@ class Piece(LoggedClass):
         """
         self.labels_cfg.update(update_labels_cfg(labels_cfg, logger=self.logger))
 
-    def all_facets_present(self, view_name: Optional[str] = None,
-                           selected_facets: Optional[Facets] = None) -> bool:
-        """ Checks if parsed TSV files have been detected for all selected facets under the active or indicated view.
+    def all_facets_present(
+        self, view_name: Optional[str] = None, selected_facets: Optional[Facets] = None
+    ) -> bool:
+        """Checks if parsed TSV files have been detected for all selected facets under the active or indicated view.
 
         Args:
           view_name: Name of the view to check.
@@ -101,15 +149,24 @@ class Piece(LoggedClass):
             facets = resolve_facets_param(selected_facets, none_means_all=False)
             missing = [f for f in facets if f not in view_facets]
             if len(missing) > 0:
-                plural = 's are' if len(missing) > 1 else ' is'
-                self.logger.warning(f"The following facet{plural} excluded from the view '{view.name}': {missing}")
+                plural = "s are" if len(missing) > 1 else " is"
+                self.logger.warning(
+                    f"The following facet{plural} excluded from the view '{view.name}': {missing}"
+                )
                 return False
-        present_facets = [typ for typ, _ in self.iter_facet2files(view_name=view_name, include_empty=False)]
+        present_facets = [
+            typ
+            for typ, _ in self.iter_facet2files(
+                view_name=view_name, include_empty=False
+            )
+        ]
         result = all(f in present_facets for f in facets)
         if not result:
             missing = [f for f in facets if f not in present_facets]
-            plural = 's are' if len(missing) > 1 else ' is'
-            self.logger.debug(f"The following facet{plural} not present under the view '{view.name}': {missing}")
+            plural = "s are" if len(missing) > 1 else " is"
+            self.logger.debug(
+                f"The following facet{plural} not present under the view '{view.name}': {missing}"
+            )
         return result
 
     @property
@@ -133,21 +190,29 @@ class Piece(LoggedClass):
         self._ms = get_musescore(ms, logger=self.logger)
 
     @overload
-    def score_metadata(self,
-                       view_name: Optional[str],
-                       choose: Literal['auto', 'ask'],
-                       as_dict: Literal[False]) -> pd.Series:
+    def score_metadata(
+        self,
+        view_name: Optional[str],
+        choose: Literal["auto", "ask"],
+        as_dict: Literal[False],
+    ) -> pd.Series:
         ...
+
     @overload
-    def score_metadata(self,
-                       view_name: Optional[str],
-                       choose: Literal['auto', 'ask'],
-                       as_dict: Literal[True]) -> dict:
+    def score_metadata(
+        self,
+        view_name: Optional[str],
+        choose: Literal["auto", "ask"],
+        as_dict: Literal[True],
+    ) -> dict:
         ...
-    def score_metadata(self,
-                       view_name: Optional[str] = None,
-                       choose: Literal['auto', 'ask'] = 'auto',
-                       as_dict: bool = False) -> Union[pd.Series, dict, Literal[None]]:
+
+    def score_metadata(
+        self,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        as_dict: bool = False,
+    ) -> Union[pd.Series, dict, Literal[None]]:
         """
 
         Args:
@@ -161,9 +226,9 @@ class Piece(LoggedClass):
         if score is None:
             return None
         meta_dict = score.mscx.metadata
-        meta_dict['subdirectory'] = file.subdir
-        meta_dict['piece'] = self.name
-        meta_dict['rel_path'] = file.rel_path
+        meta_dict["subdirectory"] = file.subdir
+        meta_dict["piece"] = self.name
+        meta_dict["rel_path"] = file.rel_path
         if as_dict:
             return meta_dict
         return metadata2series(meta_dict)
@@ -175,7 +240,7 @@ class Piece(LoggedClass):
         """
         return self._tsv_metadata
 
-    def metadata(self, view_name : Optional[str] = None) -> Optional[pd.Series]:
+    def metadata(self, view_name: Optional[str] = None) -> Optional[pd.Series]:
         """If a row of 'metadata.tsv' has been stored, return that, otherwise extract from a (force-)parsed score."""
         if self.tsv_metadata is not None:
             return self.tsv_metadata
@@ -186,8 +251,10 @@ class Piece(LoggedClass):
         if active is not None:
             new_name = active.name
             if new_name in self._views and active != self._views[new_name]:
-                self.logger.info(f"The existing view called '{new_name}' has been overwritten")
-                del (self._views[new_name])
+                self.logger.info(
+                    f"The existing view called '{new_name}' has been overwritten"
+                )
+                del self._views[new_name]
             old_view = self._views[None]
             self._views[old_view.name] = old_view
             self._views[None] = active
@@ -196,10 +263,7 @@ class Piece(LoggedClass):
                 view.name = view_name
             self._views[view_name] = view
 
-    def get_view(self,
-                 view_name: Optional[str] = None,
-                 **config
-                 ) -> View:
+    def get_view(self, view_name: Optional[str] = None, **config) -> View:
         """Retrieve an existing or create a new View object, potentially while updating the config."""
         if view_name in self._views:
             view = self._views[view_name]
@@ -217,18 +281,24 @@ class Piece(LoggedClass):
     def view(self):
         return self.get_view()
 
-
     @view.setter
     def view(self, new_view: View):
         if not isinstance(new_view, View):
-            return TypeError("If you want to switch to an existing view, use its name like an attribute or "
-                             "call _.switch_view().")
+            return TypeError(
+                "If you want to switch to an existing view, use its name like an attribute or "
+                "call _.switch_view()."
+            )
         self.set_view(new_view)
 
     @property
     def views(self):
-        print(pretty_dict({"[active]" if k is None else k: v for k, v in self._views.items()}, "view_name",
-                          "Description"))
+        print(
+            pretty_dict(
+                {"[active]" if k is None else k: v for k, v in self._views.items()},
+                "view_name",
+                "Description",
+            )
+        )
 
     @property
     def view_name(self):
@@ -241,7 +311,9 @@ class Piece(LoggedClass):
 
     @property
     def view_names(self):
-        return {view.name if name is None else name for name, view in self._views.items()}
+        return {
+            view.name if name is None else name for name, view in self._views.items()
+        }
 
     def __getattr__(self, view_name):
         if view_name in self.view_names:
@@ -249,191 +321,251 @@ class Piece(LoggedClass):
                 self.switch_view(view_name, show_info=False)
             return self
         else:
-            raise AttributeError(f"'{view_name}' is not an existing view. Use _.get_view('{view_name}') to create it.")
+            raise AttributeError(
+                f"'{view_name}' is not an existing view. Use _.get_view('{view_name}') to create it."
+            )
 
     def __getitem__(self, ix) -> ParsedFile:
         return self._get_parsed_at_index(ix)
 
-
     def __repr__(self):
         return self.info(return_str=True)
 
-    def cadences(self,
-                  view_name: Optional[str] = None,
-                  choose: Literal['auto', 'ask'] = 'auto',
-                  unfold: bool = False,
-                  interval_index: bool = False) -> Optional[pd.DataFrame]:
-        file, df = self.get_facet('cadences',
-                              view_name=view_name,
-                              choose=choose,
-                              unfold=unfold,
-                              interval_index=interval_index)
+    def cadences(
+        self,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Optional[pd.DataFrame]:
+        file, df = self.get_facet(
+            "cadences",
+            view_name=view_name,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         self.logger.debug(f"Returning {file}.")
         return df
 
-    def chords(self,
-                  view_name: Optional[str] = None,
-                  choose: Literal['auto', 'ask'] = 'auto',
-                  unfold: bool = False,
-                  interval_index: bool = False) -> Optional[pd.DataFrame]:
-        file, df = self.get_facet('chords',
-                              view_name=view_name,
-                              choose=choose,
-                              unfold=unfold,
-                              interval_index=interval_index)
+    def chords(
+        self,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Optional[pd.DataFrame]:
+        file, df = self.get_facet(
+            "chords",
+            view_name=view_name,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         self.logger.debug(f"Returning {file}.")
         return df
 
-    def events(self,
-                  view_name: Optional[str] = None,
-                  choose: Literal['auto', 'ask'] = 'auto',
-                  unfold: bool = False,
-                  interval_index: bool = False) -> Optional[pd.DataFrame]:
-        file, df = self.get_facet('events',
-                              view_name=view_name,
-                              choose=choose,
-                              unfold=unfold,
-                              interval_index=interval_index)
+    def events(
+        self,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Optional[pd.DataFrame]:
+        file, df = self.get_facet(
+            "events",
+            view_name=view_name,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         self.logger.debug(f"Returning {file}.")
         return df
 
-    def expanded(self,
-                  view_name: Optional[str] = None,
-                  choose: Literal['auto', 'ask'] = 'auto',
-                  unfold: bool = False,
-                  interval_index: bool = False) -> Optional[pd.DataFrame]:
-        file, df = self.get_facet('expanded',
-                              view_name=view_name,
-                              choose=choose,
-                              unfold=unfold,
-                              interval_index=interval_index)
+    def expanded(
+        self,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Optional[pd.DataFrame]:
+        file, df = self.get_facet(
+            "expanded",
+            view_name=view_name,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         self.logger.debug(f"Returning {file}.")
         return df
 
-    def form_labels(self,
-                  view_name: Optional[str] = None,
-                  choose: Literal['auto', 'ask'] = 'auto',
-                  unfold: bool = False,
-                  interval_index: bool = False) -> Optional[pd.DataFrame]:
-        file, df = self.get_facet('form_labels',
-                              view_name=view_name,
-                              choose=choose,
-                              unfold=unfold,
-                              interval_index=interval_index)
+    def form_labels(
+        self,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Optional[pd.DataFrame]:
+        file, df = self.get_facet(
+            "form_labels",
+            view_name=view_name,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         self.logger.debug(f"Returning {file}.")
         return df
 
-    def labels(self,
-                  view_name: Optional[str] = None,
-                  choose: Literal['auto', 'ask'] = 'auto',
-                  unfold: bool = False,
-                  interval_index: bool = False) -> Optional[pd.DataFrame]:
-        file, df = self.get_facet('labels',
-                              view_name=view_name,
-                              choose=choose,
-                              unfold=unfold,
-                              interval_index=interval_index)
+    def labels(
+        self,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Optional[pd.DataFrame]:
+        file, df = self.get_facet(
+            "labels",
+            view_name=view_name,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         self.logger.debug(f"Returning {file}.")
         return df
 
-    def measures(self,
-                  view_name: Optional[str] = None,
-                  choose: Literal['auto', 'ask'] = 'auto',
-                  unfold: bool = False,
-                  interval_index: bool = False) -> Optional[pd.DataFrame]:
-        file, df = self.get_facet('measures',
-                              view_name=view_name,
-                              choose=choose,
-                              unfold=unfold,
-                              interval_index=interval_index)
+    def measures(
+        self,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Optional[pd.DataFrame]:
+        file, df = self.get_facet(
+            "measures",
+            view_name=view_name,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         self.logger.debug(f"Returning {file}.")
         return df
 
-    def notes(self,
-                  view_name: Optional[str] = None,
-                  choose: Literal['auto', 'ask'] = 'auto',
-                  unfold: bool = False,
-                  interval_index: bool = False) -> Optional[pd.DataFrame]:
-        file, df = self.get_facet('notes',
-                              view_name=view_name,
-                              choose=choose,
-                              unfold=unfold,
-                              interval_index=interval_index)
+    def notes(
+        self,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Optional[pd.DataFrame]:
+        file, df = self.get_facet(
+            "notes",
+            view_name=view_name,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         self.logger.debug(f"Returning {file}.")
         return df
 
-    def notes_and_rests(self,
-                  view_name: Optional[str] = None,
-                  choose: Literal['auto', 'ask'] = 'auto',
-                  unfold: bool = False,
-                  interval_index: bool = False) -> Optional[pd.DataFrame]:
-        file, df = self.get_facet('notes_and_rests',
-                              view_name=view_name,
-                              choose=choose,
-                              unfold=unfold,
-                              interval_index=interval_index)
+    def notes_and_rests(
+        self,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Optional[pd.DataFrame]:
+        file, df = self.get_facet(
+            "notes_and_rests",
+            view_name=view_name,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         self.logger.debug(f"Returning {file}.")
         return df
 
-    def rests(self,
-                  view_name: Optional[str] = None,
-                  choose: Literal['auto', 'ask'] = 'auto',
-                  unfold: bool = False,
-                  interval_index: bool = False) -> Optional[pd.DataFrame]:
-        file, df = self.get_facet('rests',
-                              view_name=view_name,
-                              choose=choose,
-                              unfold=unfold,
-                              interval_index=interval_index)
+    def rests(
+        self,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Optional[pd.DataFrame]:
+        file, df = self.get_facet(
+            "rests",
+            view_name=view_name,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         self.logger.debug(f"Returning {file}.")
         return df
 
-    def score(self,
-                  view_name: Optional[str] = None,
-                  choose: Literal['auto', 'ask'] = 'auto') -> Optional[Score]:
-        file, score = self.get_parsed('scores',
-                              view_name=view_name,
-                              choose=choose)
+    def score(
+        self, view_name: Optional[str] = None, choose: Literal["auto", "ask"] = "auto"
+    ) -> Optional[Score]:
+        file, score = self.get_parsed("scores", view_name=view_name, choose=choose)
         self.logger.debug(f"Returning {file}.")
         return score
 
-
     def add_parsed_score(self, ix: int, score_obj: Score) -> None:
-        assert ix in self.ix2file, f"Piece '{self.name}' does not include a file with index {ix}."
+        assert (
+            ix in self.ix2file
+        ), f"Piece '{self.name}' does not include a file with index {ix}."
         if score_obj is None:
             file = self.ix2file[ix]
-            self.logger.debug(f"I was promised the parsed score for '{file.rel_path}' but received None.")
+            self.logger.debug(
+                f"I was promised the parsed score for '{file.rel_path}' but received None."
+            )
             return
         self.ix2parsed[ix] = score_obj
         self.ix2parsed_score[ix] = score_obj
-        self.facet2parsed['scores'][ix] = score_obj
+        self.facet2parsed["scores"][ix] = score_obj
 
     def add_parsed_tsv(self, ix: int, parsed_tsv: pd.DataFrame) -> None:
-        assert ix in self.ix2file, f"Piece '{self.name}' does not include a file with index {ix}."
+        assert (
+            ix in self.ix2file
+        ), f"Piece '{self.name}' does not include a file with index {ix}."
         if parsed_tsv is None:
             file = self.ix2file[ix]
-            self.logger.debug(f"I was promised the parsed DataFrame for '{file.rel_path}' but received None.")
+            self.logger.debug(
+                f"I was promised the parsed DataFrame for '{file.rel_path}' but received None."
+            )
             return
         self.ix2parsed[ix] = parsed_tsv
         self.ix2parsed_tsv[ix] = parsed_tsv
         inferred_type = infer_tsv_type(parsed_tsv)
         file = self.ix2file[ix]
         if file.type != inferred_type:
-            if inferred_type == 'unknown':
-                self.logger.info(f"After parsing '{file.rel_path}', the original guess that it contains '{file.type}' "
-                                 f"seems to be False and I'm attributing it to the facet '{file.type}'.")
+            if inferred_type == "unknown":
+                self.logger.info(
+                    f"After parsing '{file.rel_path}', the original guess that it contains '{file.type}' "
+                    f"seems to be False and I'm attributing it to the facet '{file.type}'."
+                )
             else:
-                self.logger.info(f"File {file.rel_path} turned out to contain '{inferred_type}' instead of '{file.type}', "
-                             f"as I had guessed from its path.")
+                self.logger.info(
+                    f"File {file.rel_path} turned out to contain '{inferred_type}' instead of '{file.type}', "
+                    f"as I had guessed from its path."
+                )
             self.facet2files[file.type].remove(file)
             file.type = inferred_type
             self.facet2files[inferred_type].append(file)
         self.facet2parsed[inferred_type][ix] = parsed_tsv
-        if inferred_type in ('labels', 'expanded'):
-            self.ix2annotations = Annotations(df = parsed_tsv)
+        if inferred_type in ("labels", "expanded"):
+            self.ix2annotations = Annotations(df=parsed_tsv)
 
-    def change_labels_cfg(self, labels_cfg=(), staff=None, voice=None, harmony_layer=None, positioning=None, decode=None, column_name=None, color_format=None):
-        """ Update :obj:`Piece.labels_cfg` and retrieve new 'labels' tables accordingly.
+    def change_labels_cfg(
+        self,
+        labels_cfg=(),
+        staff=None,
+        voice=None,
+        harmony_layer=None,
+        positioning=None,
+        decode=None,
+        column_name=None,
+        color_format=None,
+    ):
+        """Update :obj:`Piece.labels_cfg` and retrieve new 'labels' tables accordingly.
 
         Parameters
         ----------
@@ -442,7 +574,15 @@ class Piece(LoggedClass):
         staff, voice, harmony_layer, positioning, decode, column_name
             Arguments as they will be passed to :py:meth:`~ms3.annotations.Annotations.get_labels`
         """
-        keys = ['staff', 'voice', 'harmony_layer', 'positioning', 'decode', 'column_name', 'color_format']
+        keys = [
+            "staff",
+            "voice",
+            "harmony_layer",
+            "positioning",
+            "decode",
+            "column_name",
+            "color_format",
+        ]
         labels_cfg = dict(labels_cfg)
         for k in keys:
             val = locals()[k]
@@ -453,23 +593,25 @@ class Piece(LoggedClass):
         for score in self.ix2parsed_score.values():
             score.change_labels_cfg(labels_cfg=self.labels_cfg)
 
-    def compare_labels(self,
-                       key: str = 'detached',
-                       new_color: str = 'ms3_darkgreen',
-                       old_color: str = 'ms3_darkred',
-                       detached_is_newer: bool = False,
-                       add_to_rna: bool = True,
-                       view_name: Optional[str] = None) -> Tuple[int, int]:
-        """ Compare detached labels ``key`` to the ones attached to the Score to create a diff.
-        By default, the attached labels are considered as the reviewed version and labels that have changed or been added
-        in comparison to the detached labels are colored in green; whereas the previous versions of changed labels are
-        attached to the Score in red, just like any deleted label.
+    def compare_labels(
+        self,
+        key: str = "detached",
+        new_color: str = "ms3_darkgreen",
+        old_color: str = "ms3_darkred",
+        detached_is_newer: bool = False,
+        add_to_rna: bool = True,
+        view_name: Optional[str] = None,
+    ) -> Tuple[int, int]:
+        """Compare detached labels ``key`` to the ones attached to the Score to create a diff.
+        By default, the attached labels are considered as the reviewed version and labels that have changed or been
+        added in comparison to the detached labels are colored in green; whereas the previous versions of changed
+        labels are attached to the Score in red, just like any deleted label.
 
         Args:
           key: Key of the detached labels you want to compare to the ones in the score.
           new_color, old_color:
-              The colors by which new and old labels are differentiated. Identical labels remain unchanged. Colors can be
-              CSS colors or MuseScore colors (see :py:attr:`utils.MS3_COLORS`).
+              The colors by which new and old labels are differentiated. Identical labels remain unchanged. Colors can
+              be CSS colors or MuseScore colors (see :py:attr:`utils.MS3_COLORS`).
           detached_is_newer:
               Pass True if the detached labels are to be added with ``new_color`` whereas the attached changed labels
               will turn ``old_color``, as opposed to the default.
@@ -484,11 +626,13 @@ class Piece(LoggedClass):
         changed, unchanged = 0, 0
         for file, score in self.get_parsed_scores(view_name=view_name):
             if key in score._detached_annotations:
-                changes = score.compare_labels(key=key,
-                                     new_color=new_color,
-                                     old_color=old_color,
-                                     detached_is_newer=detached_is_newer,
-                                     add_to_rna=add_to_rna)
+                changes = score.compare_labels(
+                    key=key,
+                    new_color=new_color,
+                    old_color=old_color,
+                    detached_is_newer=detached_is_newer,
+                    add_to_rna=add_to_rna,
+                )
                 if changes > (0, 0):
                     changed += 1
                 else:
@@ -499,18 +643,24 @@ class Piece(LoggedClass):
         parsed_scores = self.get_parsed_scores(view_name=view_name)
         return sum(score.mscx.changed for _, score in parsed_scores)
 
-    def count_parsed(self, include_empty=False, view_name: Optional[str] = None, prefix: bool = False) -> Dict[str, int]:
+    def count_parsed(
+        self, include_empty=False, view_name: Optional[str] = None, prefix: bool = False
+    ) -> Dict[str, int]:
         result = {}
-        for typ, parsed in self.iter_facet2parsed(view_name=view_name, include_empty=include_empty):
-            key = 'parsed_' + typ if prefix else typ
+        for typ, parsed in self.iter_facet2parsed(
+            view_name=view_name, include_empty=include_empty
+        ):
+            key = "parsed_" + typ if prefix else typ
             result[key] = len(parsed)
         return result
 
-    def count_detected(self,
-                       include_empty: bool = False,
-                       view_name: Optional[str] = None,
-                       prefix: bool = False) -> Dict[str, int]:
-        """ Count how many files per facet have been detected.
+    def count_detected(
+        self,
+        include_empty: bool = False,
+        view_name: Optional[str] = None,
+        prefix: bool = False,
+    ) -> Dict[str, int]:
+        """Count how many files per facet have been detected.
 
         Args:
           include_empty:
@@ -522,53 +672,62 @@ class Piece(LoggedClass):
           {facet -> count of detected files}
         """
         result = {}
-        for facet, files in self.iter_facet2files(view_name=view_name, include_empty=include_empty):
-            key = 'detected_' + facet if prefix else facet
+        for facet, files in self.iter_facet2files(
+            view_name=view_name, include_empty=include_empty
+        ):
+            key = "detected_" + facet if prefix else facet
             result[key] = len(files)
         return result
 
-    def extract_facet(self,
-                      facet: ScoreFacet,
-                      view_name: Optional[str] = None,
-                      force: bool = False,
-                      choose: Literal['auto', 'ask'] = 'auto',
-                      unfold: bool = False,
-                      interval_index: bool = False,
-                 ) -> FileDataframeTupleMaybe:
-        facet = check_argument_against_literal_type(facet, ScoreFacet, logger=self.logger)
+    def extract_facet(
+        self,
+        facet: ScoreFacet,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> FileDataframeTupleMaybe:
+        facet = check_argument_against_literal_type(
+            facet, ScoreFacet, logger=self.logger
+        )
         assert facet is not None, f"Pass a valid facet {ScoreFacet.__args__}"
-        assert choose != 'all', "If you want to choose='all', use _.extract_facets() (plural)."
-        df_list = self.extract_facets(facets=facet,
-                                      view_name=view_name,
-                                      force=force,
-                                      choose=choose,
-                                      unfold=unfold,
-                                      interval_index=interval_index,
-                                      flat=True
-                                      )
+        assert (
+            choose != "all"
+        ), "If you want to choose='all', use _.extract_facets() (plural)."
+        df_list = self.extract_facets(
+            facets=facet,
+            view_name=view_name,
+            force=force,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+            flat=True,
+        )
         if len(df_list) == 0:
             return None, None
         if len(df_list) == 1:
             return df_list[0]
 
-    def extract_facets(self,
-                       facets: ScoreFacets = None,
-                       view_name: Optional[str] = None,
-                       force: bool = False,
-                       choose: Literal['all', 'auto', 'ask'] = 'all',
-                       unfold: bool = False,
-                       interval_index: bool = False,
-                       flat=False) -> Union[Dict[str,  List[FileDataframeTuple]], List[FileDataframeTuple]]:
-        """ Retrieve a dictionary with the selected feature matrices extracted from the parsed scores.
+    def extract_facets(
+        self,
+        facets: ScoreFacets = None,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        choose: Literal["all", "auto", "ask"] = "all",
+        unfold: bool = False,
+        interval_index: bool = False,
+        flat=False,
+    ) -> Union[Dict[str, List[FileDataframeTuple]], List[FileDataframeTuple]]:
+        """Retrieve a dictionary with the selected feature matrices extracted from the parsed scores.
         If you want to retrieve parsed TSV files, use :py:meth:`get_all_parsed`.
         """
         selected_facets = resolve_facets_param(facets, ScoreFacet, logger=self.logger)
         assert selected_facets is not None, f"Pass a valid facet {ScoreFacet.__args__}"
         result = defaultdict(list)
-        score_files = self.get_parsed_scores(view_name=view_name,
-                                             force=force,
-                                             choose=choose
-                                             )
+        score_files = self.get_parsed_scores(
+            view_name=view_name, force=force, choose=choose
+        )
         if len(score_files) == 0:
             return [] if flat else {facet: [] for facet in selected_facets}
         for file, score_obj in score_files:
@@ -576,32 +735,39 @@ class Piece(LoggedClass):
                 self.logger.info(f"No parsed score found for '{self.name}'")
                 continue
             for facet in selected_facets:
-                df = getattr(score_obj.mscx, facet)(interval_index=interval_index, unfold=unfold)
+                df = getattr(score_obj.mscx, facet)(
+                    interval_index=interval_index, unfold=unfold
+                )
                 if df is None:
-                    self.logger.debug(f"Score({file.rel_path}).{facet}(unfold={unfold}, interval_index={interval_index}) returned None.")
+                    self.logger.debug(
+                        f"Score({file.rel_path}).{facet}(unfold={unfold}, interval_index={interval_index}) returned "
+                        f"None."
+                    )
                 else:
                     result[facet].append((file, df))
         if flat:
             return sum(result.values(), [])
         else:
-            result = {facet: result[facet] if facet in result else [] for facet in selected_facets}
+            result = {
+                facet: result[facet] if facet in result else []
+                for facet in selected_facets
+            }
         return result
 
     def get_changed_scores(self, view_name: Optional[str]) -> List[FileScoreTuple]:
         parsed_scores = self.get_parsed_scores(view_name=view_name)
         return [(file, score) for file, score in parsed_scores if score.mscx.changed]
 
-
-
-
-    def get_facets(self,
-                   facets: ScoreFacets = None,
-                   view_name: Optional[str] = None,
-                   force: bool = False,
-                   choose: Literal['all', 'auto', 'ask'] = 'all',
-                   unfold: bool = False,
-                   interval_index: bool = False,
-                   flat=False) -> Union[Dict[str, FileDataframeTuple], List[FileDataframeTuple]]:
+    def get_facets(
+        self,
+        facets: ScoreFacets = None,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        choose: Literal["all", "auto", "ask"] = "all",
+        unfold: bool = False,
+        interval_index: bool = False,
+        flat=False,
+    ) -> Union[Dict[str, FileDataframeTuple], List[FileDataframeTuple]]:
         """
         Retrieve score facets both freshly extracted from parsed scores and from parsed TSV files, depending on
         the parameters and the view in question.
@@ -627,7 +793,9 @@ class Piece(LoggedClass):
 
         """
         selected_facets = resolve_facets_param(facets, ScoreFacet, logger=self.logger)
-        assert selected_facets is not None, f"Pass at least one valid facet {ScoreFacet.__args__}"
+        assert (
+            selected_facets is not None
+        ), f"Pass at least one valid facet {ScoreFacet.__args__}"
 
         def merge_dicts(extracted_facets, parsed_facets):
             nonlocal selected_facets
@@ -652,102 +820,118 @@ class Piece(LoggedClass):
                 return sum(result.values(), [])
             return dict(result)
 
-        if choose == 'all':
-            extracted_facets = self.extract_facets(facets=selected_facets,
-                                                   view_name=view_name,
-                                                   force=force,
-                                                   unfold=unfold,
-                                                   interval_index=interval_index,
-                                                   )
-            parsed_facets = self.get_all_parsed(facets=selected_facets,
-                                                view_name=view_name,
-                                                force=force,
-                                                unfold=unfold,
-                                                interval_index=interval_index,
-                                                )
+        if choose == "all":
+            extracted_facets = self.extract_facets(
+                facets=selected_facets,
+                view_name=view_name,
+                force=force,
+                unfold=unfold,
+                interval_index=interval_index,
+            )
+            parsed_facets = self.get_all_parsed(
+                facets=selected_facets,
+                view_name=view_name,
+                force=force,
+                unfold=unfold,
+                interval_index=interval_index,
+            )
             # TODO: Unfold & interval_index for parsed facets
             return make_result(extracted_facets, parsed_facets)
 
         # The rest below makes sure that there is only one DataFrame per facet, if available
-        extracted_facets = self.extract_facets(facets=selected_facets,
-                                               view_name=view_name,
-                                               force=False,
-                                               choose=choose,
-                                               unfold=unfold,
-                                               interval_index=interval_index,
-                                               )
-        missing_facets = [facet for facet in selected_facets if len(extracted_facets[facet]) == 0]
+        extracted_facets = self.extract_facets(
+            facets=selected_facets,
+            view_name=view_name,
+            force=False,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
+        missing_facets = [
+            facet for facet in selected_facets if len(extracted_facets[facet]) == 0
+        ]
         if len(missing_facets) == 0:
             return make_result(extracted_facets)
         # facets missing, look for parsed TSV files
-        parsed_facets = self.get_all_parsed(facets=missing_facets,
-                                            view_name=view_name,
-                                            force=False,
-                                            choose=choose,
-                                            include_empty=True,
-                                            unfold=unfold,
-                                            interval_index=interval_index,
-                                            )
+        parsed_facets = self.get_all_parsed(
+            facets=missing_facets,
+            view_name=view_name,
+            force=False,
+            choose=choose,
+            include_empty=True,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         result = merge_dicts(extracted_facets, parsed_facets)
         missing_facets = [facet for facet in selected_facets if len(result[facet]) == 0]
         if len(missing_facets) == 0 or not force:
             return make_result(result)
         # there are still facets missing; force-parse TSV files first
-        parsed_facets = self.get_all_parsed(facets=missing_facets,
-                                            view_name=view_name,
-                                            force=True,
-                                            choose=choose,
-                                            include_empty=True,
-                                            unfold=unfold,
-                                            interval_index=interval_index,
-                                            )
+        parsed_facets = self.get_all_parsed(
+            facets=missing_facets,
+            view_name=view_name,
+            force=True,
+            choose=choose,
+            include_empty=True,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         result = merge_dicts(result, parsed_facets)
         missing_facets = [facet for facet in selected_facets if len(result[facet]) == 0]
         if len(missing_facets) == 0 or not force:
             return make_result(result)
         # there are still facets missing; force-parse scores as last resort
-        extracted_facets = self.extract_facets(facets=selected_facets,
-                                               view_name=view_name,
-                                               force=True,
-                                               choose=choose,
-                                               unfold=unfold,
-                                               interval_index=interval_index,
-                                               )
+        extracted_facets = self.extract_facets(
+            facets=selected_facets,
+            view_name=view_name,
+            force=True,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         return make_result(result, extracted_facets)
 
-
-    def get_facet(self,
-                  facet: ScoreFacet,
-                  view_name: Optional[str] = None,
-                  force: bool = False,
-                  choose: Literal['auto', 'ask'] = 'auto',
-                  unfold: bool = False,
-                  interval_index: bool = False) -> FileDataframeTupleMaybe:
+    def get_facet(
+        self,
+        facet: ScoreFacet,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> FileDataframeTupleMaybe:
         """Retrieve a DataFrame from a parsed score or, if unavailable, from a parsed TSV. If none have been
         parsed, first force-parse a TSV and, if not included in the given view, force-parse a score.
         """
-        facet = check_argument_against_literal_type(facet, ScoreFacet, logger=self.logger)
+        facet = check_argument_against_literal_type(
+            facet, ScoreFacet, logger=self.logger
+        )
         assert facet is not None, f"Pass a valid facet {ScoreFacet.__args__}"
-        assert choose != 'all', "If you want to choose='all', use _.extract_facets() (plural)."
-        df_list = self.get_facets(facets=facet,
-                                  view_name=view_name,
-                                  force=force,
-                                  choose=choose,
-                                  unfold=unfold,
-                                  interval_index=interval_index,
-                                  flat=True
-                                  )
+        assert (
+            choose != "all"
+        ), "If you want to choose='all', use _.extract_facets() (plural)."
+        df_list = self.get_facets(
+            facets=facet,
+            view_name=view_name,
+            force=force,
+            choose=choose,
+            unfold=unfold,
+            interval_index=interval_index,
+            flat=True,
+        )
         if len(df_list) == 0:
             return None, None
         if len(df_list) == 1:
             return df_list[0]
 
-    def get_file(self, facet: Facet,
-                 view_name: Optional[str] = None,
-                 parsed: bool = True,
-                 unparsed: bool = True,
-                 choose: Literal['auto', 'ask'] = 'auto',
-                 ) -> Optional[File]:
+    def get_file(
+        self,
+        facet: Facet,
+        view_name: Optional[str] = None,
+        parsed: bool = True,
+        unparsed: bool = True,
+        choose: Literal["auto", "ask"] = "auto",
+    ) -> Optional[File]:
         """
 
         Args:
@@ -759,34 +943,37 @@ class Piece(LoggedClass):
         """
         facet = check_argument_against_literal_type(facet, Facet, logger=self.logger)
         assert facet is not None, f"Pass a valid facet {Facet.__args__}"
-        assert choose != 'all', "If you want to choose='all', use _.get_files() (plural)."
-        files = self.get_files(facets=facet,
-                               view_name=view_name,
-                               parsed=parsed,
-                               unparsed=unparsed,
-                               choose=choose,
-                               flat=True)
+        assert (
+            choose != "all"
+        ), "If you want to choose='all', use _.get_files() (plural)."
+        files = self.get_files(
+            facets=facet,
+            view_name=view_name,
+            parsed=parsed,
+            unparsed=unparsed,
+            choose=choose,
+            flat=True,
+        )
         if len(files) == 0:
             return None
         if len(files) == 1:
             return files[0]
-
 
     def get_file_from_path(self, full_path: Optional[str] = None) -> Optional[File]:
         for file in self.files:
             if file.full_path == full_path:
                 return file
 
-
-    def get_files(self,
-                  facets: FacetArguments = None,
-                  view_name: Optional[str] = None,
-                  parsed: bool = True,
-                  unparsed: bool = True,
-                  choose: Literal['all', 'auto', 'ask'] = 'all',
-                  flat: bool = False,
-                  include_empty: bool = False,
-                  ) -> Union[Dict[str, FileList], FileList]:
+    def get_files(
+        self,
+        facets: FacetArguments = None,
+        view_name: Optional[str] = None,
+        parsed: bool = True,
+        unparsed: bool = True,
+        choose: Literal["all", "auto", "ask"] = "all",
+        flat: bool = False,
+        include_empty: bool = False,
+    ) -> Union[Dict[str, FileList], FileList]:
         """
 
         Args:
@@ -795,68 +982,94 @@ class Piece(LoggedClass):
         Returns:
           A {file_type -> [:obj:`File`] dict containing the selected Files or, if flat=True, just a list.
         """
-        assert parsed + unparsed > 0, "At least one of 'parsed' and 'unparsed' needs to be True."
+        assert (
+            parsed + unparsed > 0
+        ), "At least one of 'parsed' and 'unparsed' needs to be True."
         selected_facets = resolve_facets_param(facets, logger=self.logger)
         if selected_facets is None:
             return
         view = self.get_view(view_name=view_name)
-        selected_facets = [facet for facet in selected_facets if facet in view.selected_facets]
+        selected_facets = [
+            facet for facet in selected_facets if facet in view.selected_facets
+        ]
         if unparsed:
             facet2files = {f: self.facet2files[f] for f in selected_facets}
         else:
             # i.e., parsed must be True
             facet2files = {f: self.facet2files[f] for f in selected_facets}
-            facet2files = {typ: [f for f in files if f.ix in self.ix2parsed] for typ, files in facet2files.items()}
+            facet2files = {
+                typ: [f for f in files if f.ix in self.ix2parsed]
+                for typ, files in facet2files.items()
+            }
         if not parsed:
             # i.e., unparsed must be True
-            facet2files = {typ: [f for f in files if f.ix not in self.ix2parsed] for typ, files in facet2files.items()}
-        facet2files = {typ: view.filtered_file_list(files) for typ, files in facet2files.items()}
+            facet2files = {
+                typ: [f for f in files if f.ix not in self.ix2parsed]
+                for typ, files in facet2files.items()
+            }
+        facet2files = {
+            typ: view.filtered_file_list(files) for typ, files in facet2files.items()
+        }
         result = {}
         needs_choice = []
         for facet, files in facet2files.items():
             n_files = len(files)
             if n_files == 0 and not include_empty:
                 continue
-            elif choose == 'all' or n_files < 2:
+            elif choose == "all" or n_files < 2:
                 result[facet] = files
             else:
                 selected = files2disambiguation_dict(files, logger=self.logger)
                 needs_choice.append(facet)
                 result[facet] = selected
-        if choose == 'auto':
+        if choose == "auto":
             for typ in needs_choice:
-                result[typ] = [automatically_choose_from_disambiguated_files(result[typ], self.name, typ)]
-        elif choose == 'ask':
+                result[typ] = [
+                    automatically_choose_from_disambiguated_files(
+                        result[typ], self.name, typ
+                    )
+                ]
+        elif choose == "ask":
             for typ in needs_choice:
                 choices = result[typ]
-                selected = ask_user_to_choose_from_disambiguated_files(choices, self.name, typ)
+                selected = ask_user_to_choose_from_disambiguated_files(
+                    choices, self.name, typ
+                )
                 if selected is None:
                     if include_empty:
                         result[typ] = []
                     else:
-                        del(result[typ])
+                        del result[typ]
                 else:
                     result[typ] = [selected]
-        elif choose == 'all' and 'scores' in needs_choice:
+        elif choose == "all" and "scores" in needs_choice:
             # check if any scores can be differentiated solely by means of their file extension
-            several_score_files = result['scores'].values()
+            several_score_files = result["scores"].values()
             subdir_pieces = [(file.subdir, file.piece) for file in several_score_files]
             if len(set(subdir_pieces)) < len(subdir_pieces):
-                duplicates = {tup: [] for tup, cnt in Counter(subdir_pieces).items() if cnt > 1}
+                duplicates = {
+                    tup: [] for tup, cnt in Counter(subdir_pieces).items() if cnt > 1
+                }
                 for file in several_score_files:
                     if (file.subdir, file.piece) in duplicates:
                         duplicates[(file.subdir, file.piece)].append(file.rel_path)
-                display_duplicates = '\n'.join(str(sorted(files)) for files in duplicates.values())
-                self.logger.warning(f"The following scores are lying in the same subfolder and have the same name:\n{display_duplicates}.\n"
-                                    f"TSV files extracted from them will be overwriting each other. Consider excluding certain "
-                                    f"file extensions or letting me choose='auto'.")
+                display_duplicates = "\n".join(
+                    str(sorted(files)) for files in duplicates.values()
+                )
+                self.logger.warning(
+                    f"The following scores are lying in the same subfolder and have the same name:\n"
+                    f"{display_duplicates}.\n"
+                    f"TSV files extracted from them will be overwriting each other. Consider excluding certain "
+                    f"file extensions or letting me choose='auto'."
+                )
         if flat:
             return sum(result.values(), start=[])
         return result
 
-    def _get_parsed_at_index(self,
-                             ix: int) -> ParsedFile:
-        assert ix in self.ix2file, f"Piece '{self.name}' does not include a file with index {ix}."
+    def _get_parsed_at_index(self, ix: int) -> ParsedFile:
+        assert (
+            ix in self.ix2file
+        ), f"Piece '{self.name}' does not include a file with index {ix}."
         if ix not in self.ix2parsed:
             self._parse_file_at_index(ix)
         if ix not in self.ix2parsed:
@@ -864,15 +1077,16 @@ class Piece(LoggedClass):
             raise RuntimeError(f"Unable to parse '{file.rel_path}'.")
         return self.ix2parsed[ix]
 
-    def get_parsed(self,
-                   facet: Facet,
-                   view_name: Optional[str] = None,
-                   choose: Literal['auto', 'ask'] = 'auto',
-                   git_revision: Optional[str] = None,
-                   unfold: bool = False,
-                   interval_index: bool = False
-                   ) -> FileParsedTupleMaybe:
-        """ Retrieve exactly one parsed score or TSV file. If none has been parsed, parse one automatically.
+    def get_parsed(
+        self,
+        facet: Facet,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        git_revision: Optional[str] = None,
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> FileParsedTupleMaybe:
+        """Retrieve exactly one parsed score or TSV file. If none has been parsed, parse one automatically.
 
         Args:
           facet:
@@ -885,17 +1099,23 @@ class Piece(LoggedClass):
         """
         facet = check_argument_against_literal_type(facet, Facet, logger=self.logger)
         assert facet is not None, f"Pass a valid facet {Facet.__args__}"
-        assert choose != 'all', "If you want to choose='all', use _.get_all_parsed()."
+        assert choose != "all", "If you want to choose='all', use _.get_all_parsed()."
         if git_revision is not None:
-            assert facet != 'scores', f"I don't parse scores from older commits. Check out {git_revision} yourself."
-        files = self.get_all_parsed(facets=facet,
-                                    view_name=view_name,
-                                    choose=choose,
-                                    flat=True,
-                                    unfold=unfold,
-                                    interval_index=interval_index)
+            assert (
+                facet != "scores"
+            ), f"I don't parse scores from older commits. Check out {git_revision} yourself."
+        files = self.get_all_parsed(
+            facets=facet,
+            view_name=view_name,
+            choose=choose,
+            flat=True,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         if len(files) == 0:
-            file = self.get_file(facet, view_name=view_name, parsed=False, choose=choose)
+            file = self.get_file(
+                facet, view_name=view_name, parsed=False, choose=choose
+            )
             if file is None:
                 return None, None
             if git_revision is None:
@@ -908,36 +1128,37 @@ class Piece(LoggedClass):
             if git_revision is None:
                 return files[0]
             file = files[0][0]
-        return parse_tsv_file_at_git_revision(file=file,
-                                              git_revision=git_revision)
+        return parse_tsv_file_at_git_revision(file=file, git_revision=git_revision)
 
-
-    def get_all_parsed(self,
-                       facets: FacetArguments = None,
-                       view_name: Optional[str] = None,
-                       force: bool = False,
-                       choose: Literal['all', 'auto', 'ask'] = 'all',
-                       flat: bool = False,
-                       include_empty: bool = False,
-                       unfold: bool = False,
-                       interval_index: bool = False,
-                       ) -> Union[Dict[Facet, List[FileParsedTuple]], List[FileParsedTuple]]:
+    def get_all_parsed(
+        self,
+        facets: FacetArguments = None,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        choose: Literal["all", "auto", "ask"] = "all",
+        flat: bool = False,
+        include_empty: bool = False,
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Union[Dict[Facet, List[FileParsedTuple]], List[FileParsedTuple]]:
         """Return multiple parsed files."""
         selected_facets = resolve_facets_param(facets, logger=self.logger)
         if selected_facets is None:
             return [] if flat else {}
-        facet2files = self.get_files(selected_facets, view_name=view_name, include_empty=include_empty)
+        facet2files = self.get_files(
+            selected_facets, view_name=view_name, include_empty=include_empty
+        )
         result = {}
         for facet, files in facet2files.items():
             if len(files) == 0:
-                ## implies include_empty=True
+                # implies include_empty=True
                 result[facet] = []
                 continue
             parsed_files = [file for file in files if file.ix in self.ix2parsed]
             unparsed_files = [file for file in files if file.ix not in parsed_files]
             n_parsed = len(parsed_files)
             n_unparsed = len(unparsed_files)
-            if choose=='all':
+            if choose == "all":
                 if force:
                     if n_unparsed > 0:
                         for file in unparsed_files:
@@ -948,11 +1169,13 @@ class Piece(LoggedClass):
             elif n_parsed == 0:
                 if force:
                     if n_unparsed > 1:
-                        selected = disambiguate_files(unparsed_files,
-                                                      self.name,
-                                                      facet,
-                                                      choose=choose,
-                                                      logger=self.logger)
+                        selected = disambiguate_files(
+                            unparsed_files,
+                            self.name,
+                            facet,
+                            choose=choose,
+                            logger=self.logger,
+                        )
                         if selected is None:
                             if include_empty:
                                 result[facet] = []
@@ -966,25 +1189,36 @@ class Piece(LoggedClass):
             elif n_parsed == 1:
                 files = parsed_files
             else:
-                selected = disambiguate_files(parsed_files,
-                                              self.name,
-                                              facet,
-                                              choose=choose,
-                                              logger=self.logger)
+                selected = disambiguate_files(
+                    parsed_files, self.name, facet, choose=choose, logger=self.logger
+                )
                 if selected is None:
                     if include_empty:
                         result[facet] = []
                     continue
                 files = [selected]
             if n_unparsed > 0:
-                plural = 'files' if n_unparsed > 1 else 'file'
+                plural = "files" if n_unparsed > 1 else "file"
                 try:
-                    self.logger.debug(f"Disregarded {n_unparsed} unparsed {facet} {plural}. Set force=True to automatically parse.")
+                    self.logger.debug(
+                        f"Disregarded {n_unparsed} unparsed {facet} {plural}. Set force=True to automatically parse."
+                    )
                 except AttributeError:
                     if self.logger is None:
-                        raise RuntimeError("The logger is None. This happens when __getstate__ is called. Did you use copy()?")
+                        raise RuntimeError(
+                            "The logger is None. This happens when __getstate__ is called. Did you use copy()?"
+                        )
                     raise
-            parsed_files = [(file, self._get_transformed_facet_at_ix(ix=file.ix, unfold=unfold, interval_index=interval_index)) for file in files if file.ix in self.ix2parsed]
+            parsed_files = [
+                (
+                    file,
+                    self._get_transformed_facet_at_ix(
+                        ix=file.ix, unfold=unfold, interval_index=interval_index
+                    ),
+                )
+                for file in files
+                if file.ix in self.ix2parsed
+            ]
             parsed_files = [(file, df) for file, df in parsed_files if df is not None]
             n_parsed = len(parsed_files)
             if n_parsed == 0 and not include_empty:
@@ -994,37 +1228,49 @@ class Piece(LoggedClass):
             return sum(result.values(), start=[])
         return result
 
-
-    def _get_transformed_facet_at_ix(self,
-                                     ix: int,
-                                     unfold: bool = False,
-                                     interval_index: bool = False) -> Optional[ParsedFile]:
-        """Retrieves a parsed TSV file, adds quarterbeats if missing and, if requested, unfolds repeats or adds a :obj:`pandas.IntervalIndex`."""
+    def _get_transformed_facet_at_ix(
+        self, ix: int, unfold: bool = False, interval_index: bool = False
+    ) -> Optional[ParsedFile]:
+        """Retrieves a parsed TSV file, adds quarterbeats if missing and, if requested, unfolds repeats or adds a
+        :obj:`pandas.IntervalIndex`.
+        """
         if ix not in self.ix2parsed:
             return None
         if ix not in self.ix2parsed_tsv:
             # this is a score and will not be transformed in any way
             return self.ix2parsed[ix]
         df = self.ix2parsed_tsv[ix]
-        qb_missing = any(c not in df.columns for c in ('quarterbeats', 'duration_qb'))
+        qb_missing = any(c not in df.columns for c in ("quarterbeats", "duration_qb"))
         if interval_index or unfold or qb_missing:
             file = self.ix2file[ix]
             if unfold or qb_missing:
-                if file.type != 'measures':
-                    _, measures = self.get_facet('measures')
+                if file.type != "measures":
+                    _, measures = self.get_facet("measures")
                 else:
                     measures = df
                 if measures is None:
                     if unfold:
-                        self.logger.warning(f"Piece.get_facet('measures') did not return a measures table, which is required for unfolding repeats. "
-                                            f"Make sure that the view includes a TSV file or a score for '{self.name}' so I can get it. Returning None for now.")
+                        self.logger.warning(
+                            f"Piece.get_facet('measures') did not return a measures table, which is required for "
+                            f"unfolding repeats. Make sure that the view includes a TSV file or a score for "
+                            f"'{self.name}' so I can get it. Returning None for now."
+                        )
                         return None
                     # else: qb_missing
-                    self.logger.warning(f"Piece.get_facet('measures') did not return a measures table, which is required for adding the "
-                                        f"missing columns 'quarterbeats' and 'duration_qb'. Make sure that the view includes a TSV file or a score "
-                                        f"for '{self.name}' so I can get it. Returning a DataFrame without these columns for now.")
+                    self.logger.warning(
+                        f"Piece.get_facet('measures') did not return a measures table, which is required for adding "
+                        f"the missing columns 'quarterbeats' and 'duration_qb'. Make sure that the view includes a "
+                        f"TSV file or a score for '{self.name}' so I can get it. Returning a DataFrame without these "
+                        f"columns for now."
+                    )
                     return df
-                transformed = dfs2quarterbeats(df, measures=measures, unfold=unfold, interval_index=interval_index, logger=self.logger)
+                transformed = dfs2quarterbeats(
+                    df,
+                    measures=measures,
+                    unfold=unfold,
+                    interval_index=interval_index,
+                    logger=self.logger,
+                )
                 if len(transformed) == 0:
                     return
                 df = transformed[0]
@@ -1032,50 +1278,63 @@ class Piece(LoggedClass):
                 df = replace_index_by_intervals(df, logger=self.logger)
         return df
 
+    def get_parsed_score(
+        self, view_name: Optional[str] = None, choose: Literal["auto", "ask"] = "auto"
+    ) -> FileScoreTupleMaybe:
+        return self.get_parsed("scores", view_name=view_name, choose=choose)
 
-    def get_parsed_score(self,
-                         view_name: Optional[str] = None,
-                         choose: Literal['auto', 'ask'] = 'auto') -> FileScoreTupleMaybe:
-        return self.get_parsed('scores', view_name=view_name, choose=choose)
+    def get_parsed_scores(
+        self,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        choose: Literal["all", "auto", "ask"] = "all",
+    ) -> List[FileScoreTuple]:
+        return self.get_all_parsed(
+            "scores", view_name=view_name, force=force, choose=choose, flat=True
+        )
 
-    def get_parsed_scores(self,
-                         view_name: Optional[str] = None,
-                         force: bool = False,
-                         choose: Literal['all', 'auto', 'ask'] = 'all') -> List[FileScoreTuple]:
-        return self.get_all_parsed('scores', view_name=view_name, force=force, choose=choose, flat=True)
-
-    def get_parsed_tsv(self,
-                       facet: TSVtype,
-                       view_name: Optional[str] = None,
-                       choose: Literal['auto', 'ask'] = 'auto',
-                       unfold: bool = False,
-                       interval_index: bool = False
-                       ) -> FileDataframeTupleMaybe:
+    def get_parsed_tsv(
+        self,
+        facet: TSVtype,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> FileDataframeTupleMaybe:
         facets = argument_and_literal_type2list(facet, TSVtype, logger=self.logger)
-        assert len(facet) == 1, f"Pass exactly one valid TSV type {TSVtype.__args__} or use _.get_parsed_tsvs()"
+        assert (
+            len(facet) == 1
+        ), f"Pass exactly one valid TSV type {TSVtype.__args__} or use _.get_parsed_tsvs()"
         facet = facets[0]
         return self.get_parsed(facet, view_name=view_name, choose=choose)
 
-    def get_parsed_tsvs(self,
-                        facets: TSVtypes,
-                        view_name: Optional[str] = None,
-                        force: bool = False,
-                        choose: Literal['all', 'auto', 'ask'] = 'all',
-                        ) -> List[FileDataframeTupleMaybe]:
+    def get_parsed_tsvs(
+        self,
+        facets: TSVtypes,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        choose: Literal["all", "auto", "ask"] = "all",
+    ) -> List[FileDataframeTupleMaybe]:
         facets = argument_and_literal_type2list(facets, TSVtype, logger=self.logger)
-        return self.get_all_parsed(facets, view_name=view_name, force=force, choose=choose, flat=True)
+        return self.get_all_parsed(
+            facets, view_name=view_name, force=force, choose=choose, flat=True
+        )
 
     def _get_parsed_score_files(self, view_name: Optional[str] = None) -> FileList:
-        return self.get_files('scores', view_name=view_name, unparsed=False, flat=True)
+        return self.get_files("scores", view_name=view_name, unparsed=False, flat=True)
 
-    def _get_parsed_tsv_files(self, view_name: Optional[str] = None, flat: bool = True) -> Union[FileDict, FileList]:
-        return self.get_files('tsv', view_name=view_name, unparsed=False, flat=flat)
+    def _get_parsed_tsv_files(
+        self, view_name: Optional[str] = None, flat: bool = True
+    ) -> Union[FileDict, FileList]:
+        return self.get_files("tsv", view_name=view_name, unparsed=False, flat=flat)
 
     def _get_unparsed_score_files(self, view_name: Optional[str] = None) -> FileList:
-        return self.get_files('scores', view_name=view_name, parsed=False, flat=True)
+        return self.get_files("scores", view_name=view_name, parsed=False, flat=True)
 
-    def _get_unparsed_tsv_files(self, view_name: Optional[str] = None, flat: bool = True) -> Union[FileDict, FileList]:
-        return self.get_files('tsv', view_name=view_name, parsed=False, flat=flat)
+    def _get_unparsed_tsv_files(
+        self, view_name: Optional[str] = None, flat: bool = True
+    ) -> Union[FileDict, FileList]:
+        return self.get_files("tsv", view_name=view_name, parsed=False, flat=flat)
 
     def info(self, return_str=False, view_name=None, show_discarded: bool = False):
         header = f"Piece '{self.name}'"
@@ -1092,13 +1351,17 @@ class Piece(LoggedClass):
         msg += f"View: {view}\n\n"
 
         # Show info on all files included in the active view
-        facet2files = dict(self.iter_facet2files(view_name=view_name, include_empty=False))
+        facet2files = dict(
+            self.iter_facet2files(view_name=view_name, include_empty=False)
+        )
         if len(facet2files) == 0:
             msg += "No files selected."
         else:
-            files_df = pd.concat([pd.DataFrame(files).set_index('ix') for files in facet2files.values()],
-                                 keys=facet2files.keys(),
-                                 names=['facet', 'ix'])
+            files_df = pd.concat(
+                [pd.DataFrame(files).set_index("ix") for files in facet2files.values()],
+                keys=facet2files.keys(),
+                names=["facet", "ix"],
+            )
             if len(files_df) == 0:
                 msg += "No files selected."
             else:
@@ -1106,14 +1369,16 @@ class Piece(LoggedClass):
                 for facet, ix in files_df.index:
                     parsed = ix in self.ix2parsed
                     is_parsed.append(parsed)
-                    changed_score = parsed and facet == 'scores' and self[ix].mscx.changed
+                    changed_score = (
+                        parsed and facet == "scores" and self[ix].mscx.changed
+                    )
                     has_changed.append(changed_score)
-                files_df['is_parsed'] = is_parsed
+                files_df["is_parsed"] = is_parsed
                 if any(has_changed):
-                    files_df['has_changed'] = has_changed
-                    info_columns = ['rel_path', 'is_parsed', 'has_changed']
+                    files_df["has_changed"] = has_changed
+                    info_columns = ["rel_path", "is_parsed", "has_changed"]
                 else:
-                    info_columns = ['rel_path', 'is_parsed']
+                    info_columns = ["rel_path", "is_parsed"]
                 msg += files_df[info_columns].to_string()
         changed_score_ixs = []
         ix2detached_annotations = {}
@@ -1121,62 +1386,82 @@ class Piece(LoggedClass):
             if score.mscx.changed:
                 changed_score_ixs.append(file.ix)
             if len(score._detached_annotations) > 0:
-                ix2detached_annotations[file.ix] = list(score._detached_annotations.keys())
+                ix2detached_annotations[file.ix] = list(
+                    score._detached_annotations.keys()
+                )
         has_changed = len(changed_score_ixs) > 0
         has_detached = len(ix2detached_annotations) > 0
         if has_changed or has_detached:
             msg += "\n\n"
             if has_changed:
-                plural = f"Scores {changed_score_ixs} have" if len(changed_score_ixs) > 1 else f"Score {changed_score_ixs[0]} has"
+                plural = (
+                    f"Scores {changed_score_ixs} have"
+                    if len(changed_score_ixs) > 1
+                    else f"Score {changed_score_ixs[0]} has"
+                )
                 msg += f"{plural} changed since parsing."
             if has_detached:
                 msg += pretty_dict(ix2detached_annotations, "ix", "Loaded annotations")
-        msg += '\n\n' + view.filtering_report(show_discarded=show_discarded, return_str=True)
+        msg += "\n\n" + view.filtering_report(
+            show_discarded=show_discarded, return_str=True
+        )
         if return_str:
             return msg
         print(msg)
 
-    def iter_extracted_facet(self,
-                       facet: ScoreFacet,
-                       view_name: Optional[str] = None,
-                       force: bool = False,
-                       unfold: bool = False,
-                       interval_index: bool = False) -> Iterator[FileDataframeTupleMaybe]:
-        """ Iterate through the selected facet extracted from all parsed or yet-to-parse scores.
-        """
-        facet = check_argument_against_literal_type(facet, ScoreFacet, logger=self.logger)
+    def iter_extracted_facet(
+        self,
+        facet: ScoreFacet,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Iterator[FileDataframeTupleMaybe]:
+        """Iterate through the selected facet extracted from all parsed or yet-to-parse scores."""
+        facet = check_argument_against_literal_type(
+            facet, ScoreFacet, logger=self.logger
+        )
         assert facet is not None, f"Pass a valid facet {ScoreFacet.__args__}"
-        for file in self.iter_files('scores',
-                                    view_name=view_name,
-                                    flat=True,
-                                    ):
+        for file in self.iter_files(
+            "scores",
+            view_name=view_name,
+            flat=True,
+        ):
             if file.ix not in self.ix2parsed and not force:
                 continue
             score_obj = self._get_parsed_at_index(file.ix)
             if score_obj is None:
                 self.logger.info(f"No parsed score found for '{file.rel_path}'")
                 continue
-            df = getattr(score_obj.mscx, facet)(interval_index=interval_index, unfold=unfold)
+            df = getattr(score_obj.mscx, facet)(
+                interval_index=interval_index, unfold=unfold
+            )
             if df is None:
-                self.logger.debug(f"Score({file.rel_path}).{facet}(unfold={unfold}, interval_index={interval_index}) returned None.")
+                self.logger.debug(
+                    f"Score({file.rel_path}).{facet}(unfold={unfold}, interval_index={interval_index}) returned None."
+                )
                 continue
             yield file, df
 
-    def iter_extracted_facets(self,
-                              facets: ScoreFacets,
-                              view_name: Optional[str] = None,
-                              force: bool = False,
-                              unfold: bool = False,
-                              interval_index: bool = False) -> Iterator[Tuple[File, DataframeDict]]:
-        """ Iterate through the selected facets extracted from all parsed or yet-to-parse scores.
-        """
+    def iter_extracted_facets(
+        self,
+        facets: ScoreFacets,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Iterator[Tuple[File, DataframeDict]]:
+        """Iterate through the selected facets extracted from all parsed or yet-to-parse scores."""
         selected_facets = resolve_facets_param(facets, ScoreFacet, logger=self.logger)
-        assert selected_facets is not None, f"Pass at least one valid facet {ScoreFacet.__args__}"
+        assert (
+            selected_facets is not None
+        ), f"Pass at least one valid facet {ScoreFacet.__args__}"
         facet2dataframe = {}
-        for file in self.iter_files('scores',
-                                    view_name=view_name,
-                                    flat=True,
-                                    ):
+        for file in self.iter_files(
+            "scores",
+            view_name=view_name,
+            flat=True,
+        ):
             if file.ix not in self.ix2parsed and not force:
                 continue
             score_obj = self._get_parsed_at_index(file.ix)
@@ -1184,14 +1469,20 @@ class Piece(LoggedClass):
                 self.logger.info(f"No parsed score found for '{file.rel_path}'")
                 continue
             for facet in selected_facets:
-                df = getattr(score_obj.mscx, facet)(interval_index=interval_index, unfold=unfold)
+                df = getattr(score_obj.mscx, facet)(
+                    interval_index=interval_index, unfold=unfold
+                )
                 if df is None:
-                    self.logger.debug(f"Score({file.rel_path}).{facet}(unfold={unfold}, interval_index={interval_index}) returned None.")
+                    self.logger.debug(
+                        f"Score({file.rel_path}).{facet}(unfold={unfold}, interval_index={interval_index}) returned "
+                        f"None."
+                    )
                 facet2dataframe[facet] = df
             yield file, facet2dataframe
 
-
-    def iter_facet2files(self, view_name: Optional[str] = None, include_empty: bool = False) -> Iterator[Tuple[str, FileList]]:
+    def iter_facet2files(
+        self, view_name: Optional[str] = None, include_empty: bool = False
+    ) -> Iterator[Tuple[str, FileList]]:
         """Iterating through :attr:`facet2files` under the current or specified view."""
         view = self.get_view(view_name=view_name)
         for facet, files in self.facet2files.items():
@@ -1203,70 +1494,84 @@ class Piece(LoggedClass):
                 continue
             yield facet, filtered_files
 
-
-    def iter_facet2parsed(self, view_name: Optional[str] = None, include_empty: bool = False) -> Iterator[Dict[str, FileList]]:
-        """Iterating through :attr:`facet2parsed` under the current or specified view and selecting only parsed files."""
+    def iter_facet2parsed(
+        self, view_name: Optional[str] = None, include_empty: bool = False
+    ) -> Iterator[Dict[str, FileList]]:
+        """
+        Iterating through :attr:`facet2parsed` under the current or specified view and selecting only parsed files.
+        """
         view = self.get_view(view_name=view_name)
         for facet, ix2parsed in self.facet2parsed.items():
             if facet not in view.selected_facets:
                 continue
             files = [self.ix2file[ix] for ix in ix2parsed.keys()]
-            filtered_ixs = [file.ix for file in view.filtered_file_list(files, 'parsed')]
+            filtered_ixs = [
+                file.ix for file in view.filtered_file_list(files, "parsed")
+            ]
             # the files need to be filtered even if the facet is excluded, for counting excluded files
             if len(filtered_ixs) == 0 and not include_empty:
                 continue
             yield facet, {ix: ix2parsed[ix] for ix in filtered_ixs}
 
-
-    def iter_files(self,
-                  facets: FacetArguments = None,
-                  view_name: Optional[str] = None,
-                  parsed: bool = True,
-                  unparsed: bool = True,
-                  choose: Literal['all', 'auto', 'ask'] = 'all',
-                  flat: bool = False,
-                  include_empty: bool = False,
-                  ) -> Union[Iterator[FileDict], Iterator[FileList]]:
+    def iter_files(
+        self,
+        facets: FacetArguments = None,
+        view_name: Optional[str] = None,
+        parsed: bool = True,
+        unparsed: bool = True,
+        choose: Literal["all", "auto", "ask"] = "all",
+        flat: bool = False,
+        include_empty: bool = False,
+    ) -> Union[Iterator[FileDict], Iterator[FileList]]:
         """Equivalent to iterating through the result of :meth:`get_files`."""
-        selected_files = self.get_files(facets=facets,
-                                        view_name=view_name,
-                                        parsed=parsed,
-                                        unparsed=unparsed,
-                                        choose=choose,
-                                        flat=flat,
-                                        include_empty=include_empty)
+        selected_files = self.get_files(
+            facets=facets,
+            view_name=view_name,
+            parsed=parsed,
+            unparsed=unparsed,
+            choose=choose,
+            flat=flat,
+            include_empty=include_empty,
+        )
         if flat:
             yield from selected_files
         else:
             yield from selected_files.items()
 
-    def iter_parsed(self,
-                       facet: Facet = None,
-                       view_name: Optional[str] = None,
-                       force: bool = False,
-                       choose: Literal['all', 'auto', 'ask'] = 'all',
-                       include_empty: bool = False,
-                       unfold: bool = False,
-                       interval_index: bool = False,
-                       ) -> Iterator[FileParsedTuple]:
+    def iter_parsed(
+        self,
+        facet: Facet = None,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        choose: Literal["all", "auto", "ask"] = "all",
+        include_empty: bool = False,
+        unfold: bool = False,
+        interval_index: bool = False,
+    ) -> Iterator[FileParsedTuple]:
         facet = check_argument_against_literal_type(facet, Facet, logger=self.logger)
         assert facet is not None, f"Pass a valid facet {Facet.__args__}"
-        files = self.get_all_parsed(facets=facet,
-                                         view_name=view_name,
-                                         force=force,
-                                         choose=choose,
-                                         flat=True,
-                                         include_empty=include_empty,
-                                         unfold=unfold,
-                                         interval_index=interval_index)
+        files = self.get_all_parsed(
+            facets=facet,
+            view_name=view_name,
+            force=force,
+            choose=choose,
+            flat=True,
+            include_empty=include_empty,
+            unfold=unfold,
+            interval_index=interval_index,
+        )
         yield from files
 
     def _parse_file_at_index(self, ix: int) -> None:
-        assert ix in self.ix2file, f"Piece '{self.name}' does not include a file with index {ix}."
+        assert (
+            ix in self.ix2file
+        ), f"Piece '{self.name}' does not include a file with index {ix}."
         file = self.ix2file[ix]
-        if file.type == 'scores':
+        if file.type == "scores":
             logger_cfg = dict(self.logger_cfg)
-            score = Score(file.full_path, labels_cfg=self.labels_cfg, ms=self.ms, **logger_cfg)
+            score = Score(
+                file.full_path, labels_cfg=self.labels_cfg, ms=self.ms, **logger_cfg
+            )
             if score is None:
                 self.logger.warning(f"Parsing {file.rel_path} failed.")
             else:
@@ -1282,15 +1587,17 @@ class Piece(LoggedClass):
         """Return the indices of all Files registered with this Piece."""
         return list(self.ix2file.keys())
 
-    def load_annotation_table_into_score(self,
-                                         ix: Optional[int] = None,
-                                         df: Optional[pd.DataFrame] = None,
-                                         view_name: Optional[str] = None,
-                                         choose: Literal['auto', 'ask'] = 'auto',
-                                         key: str = 'detached',
-                                         infer: bool = True,
-                                         **cols) -> None:
-        """ Attach an :py:class:`~.annotations.Annotations` object to the score and make it available as ``Score.{key}``.
+    def load_annotation_table_into_score(
+        self,
+        ix: Optional[int] = None,
+        df: Optional[pd.DataFrame] = None,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        key: str = "detached",
+        infer: bool = True,
+        **cols,
+    ) -> None:
+        """Attach an :py:class:`~.annotations.Annotations` object to the score and make it available as ``Score.{key}``.
         It can be an existing object or one newly created from the TSV file ``tsv_path``.
 
         Args:
@@ -1299,8 +1606,9 @@ class Piece(LoggedClass):
           key:
               Specify a new key for accessing the set of annotations. The string needs to be usable
               as an identifier, e.g. not start with a number, not contain special characters etc. In return you
-              may use it as a property: For example, passing ``'chords'`` lets you access the :py:class:`~.annotations.Annotations` as
-              ``Score.chords``. The key 'annotations' is reserved for all annotations attached to the score.
+              may use it as a property: For example, passing ``'chords'`` lets you access the :py:class:`~.annotations.
+              Annotations` as ``Score.chords``. The key 'annotations' is reserved for all annotations attached to the
+              score.
           infer:
               By default, the label types are inferred in the currently configured order (see :py:attr:`name2regex`).
               Pass False to not add and not change any label types.
@@ -1308,76 +1616,92 @@ class Piece(LoggedClass):
               If the columns in the specified TSV file diverge from the :ref:`standard column names<column_names>`,
               pass them as standard_name='custom name' keywords.
         """
-        assert (ix is None) + (df is None) == 1, "Pass either the index of a TSV file or a DataFrame with annotations."
+        assert (ix is None) + (
+            df is None
+        ) == 1, "Pass either the index of a TSV file or a DataFrame with annotations."
         if ix is not None:
-            assert ix in self.ix2file, f"Index {ix} is not associated with Piece '{self.name}'."
+            assert (
+                ix in self.ix2file
+            ), f"Index {ix} is not associated with Piece '{self.name}'."
             file = self.ix2file[ix]
             df = self._get_parsed_at_index(ix)
-            assert file.type in ('labels', 'expanded'), f"File needs to contain annotations, but {file.rel_path} is of type '{file.type}'."
+            assert file.type in (
+                "labels",
+                "expanded",
+            ), f"File needs to contain annotations, but {file.rel_path} is of type '{file.type}'."
         score_file, score = self.get_parsed_score(view_name=view_name, choose=choose)
         score.load_annotations(df=df, key=key, infer=infer, **cols)
 
-
-    def load_facet_into_score(self,
-                              facet: AnnotationsFacet,
-                              view_name: Optional[str] = None,
-                              choose: Literal['auto', 'ask'] = 'auto',
-                              git_revision: Optional[str] = None,
-                              key: str = 'detached',
-                              infer: bool = True,
-                              **cols) -> None:
-        facet = check_argument_against_literal_type(facet, AnnotationsFacet, logger=self.logger)
+    def load_facet_into_score(
+        self,
+        facet: AnnotationsFacet,
+        view_name: Optional[str] = None,
+        choose: Literal["auto", "ask"] = "auto",
+        git_revision: Optional[str] = None,
+        key: str = "detached",
+        infer: bool = True,
+        **cols,
+    ) -> None:
+        facet = check_argument_against_literal_type(
+            facet, AnnotationsFacet, logger=self.logger
+        )
         assert facet is not None, f"Pass a valid facet {AnnotationsFacet.__args__}"
-        file, df = self.get_parsed(facet=facet,
-                             view_name=view_name,
-                             choose=choose,
-                             git_revision=git_revision,
-                             )
-        self.load_annotation_table_into_score(df=df,
-                                              view_name=view_name,
-                                              choose=choose,
-                                              key=key,
-                                              infer=infer,
-                                              **cols)
-
+        file, df = self.get_parsed(
+            facet=facet,
+            view_name=view_name,
+            choose=choose,
+            git_revision=git_revision,
+        )
+        self.load_annotation_table_into_score(
+            df=df, view_name=view_name, choose=choose, key=key, infer=infer, **cols
+        )
 
     def register_file(self, file: File, reject_incongruent_pnames: bool = True) -> bool:
         ix = file.ix
         if ix in self.ix2file:
             existing_file = self.ix2file[ix]
             if file.full_path == existing_file.full_path:
-                self.logger.debug(f"File '{file.rel_path}' was already registered for {self.name}.")
+                self.logger.debug(
+                    f"File '{file.rel_path}' was already registered for {self.name}."
+                )
                 return None
             else:
-                self.logger.debug(f"File '{existing_file.rel_path}' replaced with '{file.rel_path}'")
+                self.logger.debug(
+                    f"File '{existing_file.rel_path}' replaced with '{file.rel_path}'"
+                )
         if file.piece != self.name:
             if file.piece.startswith(self.name):
-                file.suffix = file.piece[len(self.name):]
+                name_len = len(self.name)
+                file.suffix = file.piece[name_len:]
                 self.logger.debug(f"Recognized suffix '{file.suffix}' for {file.file}.")
             elif reject_incongruent_pnames:
                 if self.name in file.piece:
-                    self.logger.info(f"{file.file} seems to come with a prefix w.r.t. '{self.name}' and is ignored.")
+                    self.logger.info(
+                        f"{file.file} seems to come with a prefix w.r.t. '{self.name}' and is ignored."
+                    )
                     return False
                 else:
-                    self.logger.warning(f"{file.file} does not contain '{self.name}' and is ignored.")
+                    self.logger.warning(
+                        f"{file.file} does not contain '{self.name}' and is ignored."
+                    )
                     return False
         self.facet2files[file.type].append(file)
         self.ix2file[file.ix] = file
         return True
 
     def store_extracted_facet(
-            self,
-            facet: ScoreFacet,
-            root_dir: Optional[str] = None,
-            folder: Optional[str] = None,
-            view_name: Optional[str] = None,
-            force: bool = False,
-            choose: Literal['all', 'auto', 'ask'] = 'all',
-            unfold: bool = False,
-            interval_index: bool = False,
-            frictionless: bool = True,
-            raise_exception: bool = True,
-            write_or_remove_errors_file: bool = True,
+        self,
+        facet: ScoreFacet,
+        root_dir: Optional[str] = None,
+        folder: Optional[str] = None,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        choose: Literal["all", "auto", "ask"] = "all",
+        unfold: bool = False,
+        interval_index: bool = False,
+        frictionless: bool = True,
+        raise_exception: bool = True,
+        write_or_remove_errors_file: bool = True,
     ):
         """
         Extract a facet from one or several available scores and store the results as TSV files, the paths of which
@@ -1392,8 +1716,9 @@ class Piece(LoggedClass):
           folder:
               * If ``folder`` is None (default), the files' type will be appended to the ``root_dir``.
               * If ``folder`` is an absolute path, ``root_dir`` will be ignored.
-              * If ``folder`` is a relative path starting with a dot ``.`` the relative path is appended to the file's subdir.
-                For example, ``..\notes`` will resolve to a sibling directory of the one where the ``file`` is located.
+              * If ``folder`` is a relative path starting with a dot ``.`` the relative path is appended to the file's
+                subdir. For example, ``..\notes`` will resolve to a sibling directory of the one where the ``file``
+                is located.
               * If ``folder`` is a relative path that does not begin with a dot ``.``, it will be appended to the
                 ``root_dir``.
           view_name:
@@ -1404,9 +1729,12 @@ class Piece(LoggedClass):
           frictionless:
             If True (default), the file is written together with a frictionless resource descriptor JSON file
             whose column schema is used to validate the stored TSV file.
-          raise_exception:  If True (default) raise if the resource is not valid. Only relevant when frictionless=True (i.e., by default).
+          raise_exception:
+              If True (default) raise if the resource is not valid. Only relevant when frictionless=True (i.e.,
+              by default).
           write_or_remove_errors_file:
-            If True (default) write a .errors file if the resource is not valid, otherwise remove it if it exists. Only relevant when frictionless=True (i.e., by default).
+            If True (default) write a .errors file if the resource is not valid, otherwise remove it if it exists.
+            Only relevant when frictionless=True (i.e., by default).
 
 
 
@@ -1414,36 +1742,35 @@ class Piece(LoggedClass):
         Returns:
 
         """
-        if choose == 'all':
-            extracted_facet = self.iter_extracted_facet(facet=facet,
-                                                        view_name=view_name,
-                                                        force=force,
-                                                        unfold=unfold,
-                                                        interval_index=interval_index)
+        if choose == "all":
+            extracted_facet = self.iter_extracted_facet(
+                facet=facet,
+                view_name=view_name,
+                force=force,
+                unfold=unfold,
+                interval_index=interval_index,
+            )
         else:
-            extracted_facet = self.extract_facets(facets=facet,
-                                                   view_name=view_name,
-                                                   force=force,
-                                                   choose=choose,
-                                                   flat=True)
+            extracted_facet = self.extract_facets(
+                facets=facet, view_name=view_name, force=force, choose=choose, flat=True
+            )
+        create_descriptor = frictionless and facet != "events"
         for file, df in extracted_facet:
             piece_name = file.piece
             if unfold:
-                piece_name += f"_unfolded"
-            directory = compute_path_from_file(
-                file,
-                root_dir=root_dir,
-                folder=folder)
+                piece_name += "_unfolded"
+            directory = compute_path_from_file(file, root_dir=root_dir, folder=folder)
             store_dataframe_resource(
                 df=df,
                 directory=directory,
                 piece_name=piece_name,
                 facet=facet,
                 zipped=False,
-                frictionless=frictionless,
+                frictionless=create_descriptor,
                 raise_exception=raise_exception,
                 write_or_remove_errors_file=write_or_remove_errors_file,
-                logger=self.logger)
+                logger=self.logger,
+            )
 
     # def store_parsed_scores(self,
     #                         view_name: Optional[str] = None,
@@ -1463,13 +1790,15 @@ class Piece(LoggedClass):
     #         stored_file_paths.append(file_path)
     #     return stored_file_paths
 
-    def store_parsed_score_at_ix(self,
-                                 ix,
-                                 root_dir: Optional[str] = None,
-                                 folder: str = '.',
-                                 suffix: str = '',
-                                 overwrite: bool = False,
-                                 simulate=False) -> Optional[str]:
+    def store_parsed_score_at_ix(
+        self,
+        ix,
+        root_dir: Optional[str] = None,
+        folder: str = ".",
+        suffix: str = "",
+        overwrite: bool = False,
+        simulate=False,
+    ) -> Optional[str]:
         """
         Creates a MuseScore file from the Score object at the given index.
 
@@ -1485,14 +1814,12 @@ class Piece(LoggedClass):
           Path of the stored file.
         """
         if ix not in self.ix2parsed_score:
-            self.logger.error(f"No Score object found. Call parse_scores() first.")
+            self.logger.error("No Score object found. Call parse_scores() first.")
             return
         file = self.ix2file[ix]
-        file_path = make_file_path(file=file,
-                                   root_dir=root_dir,
-                                   folder=folder,
-                                   suffix=suffix,
-                                   fext='.mscx')
+        file_path = make_file_path(
+            file=file, root_dir=root_dir, folder=folder, suffix=suffix, fext=".mscx"
+        )
         if os.path.isfile(file_path):
             if simulate:
                 if overwrite:
@@ -1501,7 +1828,9 @@ class Piece(LoggedClass):
                 self.logger.warning(f"Would have skipped {file_path}.")
                 return
             elif not overwrite:
-                self.logger.warning(f"Skipping {file.rel_path} because the target file exists already and overwrite=False: {file_path}.")
+                self.logger.warning(
+                    f"Skipping {file.rel_path} because the target file exists already and overwrite=False: {file_path}."
+                )
                 return
         if simulate:
             self.logger.debug(f"Would have written score to {file_path}.")
@@ -1511,8 +1840,7 @@ class Piece(LoggedClass):
             self.logger.debug(f"Score written to {file_path}.")
         return file_path
 
-    def switch_view(self, view_name: str,
-                    show_info: bool = True) -> None:
+    def switch_view(self, view_name: str, show_info: bool = True) -> None:
         if view_name is None:
             return
         new_view = self.get_view(view_name)
@@ -1522,20 +1850,21 @@ class Piece(LoggedClass):
         self._views[None] = new_view
         new_name = new_view.name
         if new_name in self._views:
-            del (self._views[new_name])
+            del self._views[new_name]
         if show_info:
             self.info()
 
-    def update_score_metadata_from_tsv(self,
-                                       view_name: Optional[str] = None,
-                                       force: bool = False,
-                                       choose: Literal['all', 'auto', 'ask'] = 'all',
-                                       write_empty_values: bool = False,
-                                       remove_unused_fields: bool = False,
-                                       write_text_fields: bool = False,
-                                       update_instrumentation: bool = False,
-                                       ) -> List[File]:
-        """ Update metadata fields of parsed scores with the values from the corresponding row in metadata.tsv.
+    def update_score_metadata_from_tsv(
+        self,
+        view_name: Optional[str] = None,
+        force: bool = False,
+        choose: Literal["all", "auto", "ask"] = "all",
+        write_empty_values: bool = False,
+        remove_unused_fields: bool = False,
+        write_text_fields: bool = False,
+        update_instrumentation: bool = False,
+    ) -> List[File]:
+        """Update metadata fields of parsed scores with the values from the corresponding row in metadata.tsv.
 
         Args:
           view_name:
@@ -1545,36 +1874,59 @@ class Piece(LoggedClass):
               If set to True, existing values are overwritten even if the new value is empty, in which case the field
               will be set to ''.
           remove_unused_fields:
-              If set to True, all non-default fields that are not among the columns of metadata.tsv (anymore) are removed.
+              If set to True, all non-default fields that are not among the columns of metadata.tsv (anymore) are
+              removed.
           write_text_fields:
-              If set to True, ms3 will write updated values from the columns ``title_text``, ``subtitle_text``, ``composer_text``,
-              ``lyricist_text``, and ``part_name_text`` into the score header.
+              If set to True, ms3 will write updated values from the columns ``title_text``, ``subtitle_text``,
+              ``composer_text``, ``lyricist_text``, and ``part_name_text`` into the score header.
           update_instrumentation:
-              Set to True to update the score's instrumentation based on changed values from 'staff_<i>_instrument' columns.
+              Set to True to update the score's instrumentation based on changed values from 'staff_<i>_instrument'
+              columns.
 
         Returns:
           List of File objects of those scores of which the XML structure has been modified.
         """
         if self.tsv_metadata is None:
-            self.logger.info(f"No metadata available for updating scores.")
+            self.logger.info("No metadata available for updating scores.")
             return []
         updated_scores = []
-        ignore_columns = AUTOMATIC_COLUMNS + LEGACY_COLUMNS + ['piece']
-        for file, score in self.iter_parsed('scores', view_name=view_name, force=force, choose=choose):
+        ignore_columns = AUTOMATIC_COLUMNS + LEGACY_COLUMNS + ["piece"]
+        for file, score in self.iter_parsed(
+            "scores", view_name=view_name, force=force, choose=choose
+        ):
             MSCX = score.mscx.parsed
             current_metadata = MSCX.metatags.fields
             current_metadata.update(MSCX.prelims.fields)
-            row_dict = {column: value for column, value in self.tsv_metadata.items()
-                        if column not in ignore_columns and not re.match(r"^staff_\d", column)}
-            unused_fields = [field for field in current_metadata.keys() if field not in row_dict and field not in MUSESCORE_METADATA_FIELDS]
+            row_dict = {
+                column: value
+                for column, value in self.tsv_metadata.items()
+                if column not in ignore_columns and not re.match(r"^staff_\d", column)
+            }
+            unused_fields = [
+                field
+                for field in current_metadata.keys()
+                if field not in row_dict and field not in MUSESCORE_METADATA_FIELDS
+            ]
             if write_empty_values:
-                row_dict = {column: '' if pd.isnull(value) else str(value) for column, value in row_dict.items()}
+                row_dict = {
+                    column: "" if pd.isnull(value) else str(value)
+                    for column, value in row_dict.items()
+                }
             else:
-                row_dict = {column: str(value) for column, value in row_dict.items() if value != '' and not pd.isnull(value)}
-            to_be_updated = {field: value for field, value in row_dict.items()
-                             if (field not in current_metadata and value != '') or \
-                                (field in current_metadata and current_metadata[field] != value)}
-            fields_to_be_created = [field for field in to_be_updated.keys() if field not in current_metadata]
+                row_dict = {
+                    column: str(value)
+                    for column, value in row_dict.items()
+                    if value != "" and not pd.isnull(value)
+                }
+            to_be_updated = {
+                field: value
+                for field, value in row_dict.items()
+                if (field not in current_metadata and value != "")
+                or (field in current_metadata and current_metadata[field] != value)
+            }
+            fields_to_be_created = [
+                field for field in to_be_updated.keys() if field not in current_metadata
+            ]
             metadata_fields, text_fields = {}, {}
             for field, value in to_be_updated.items():
                 if field in MUSESCORE_HEADER_FIELDS:
@@ -1586,14 +1938,16 @@ class Piece(LoggedClass):
                 for field, value in text_fields.items():
                     if pd.isnull(value):
                         continue
-                    if value == '' and not write_empty_values:
+                    if value == "" and not write_empty_values:
                         continue
                     MSCX.prelims[field] = value
                     self.logger.debug(f"{file.rel_path}: {field} set to '{value}'.")
                     changed = True
             for field, value in metadata_fields.items():
-                specifier = 'New field' if field in fields_to_be_created else 'Field'
-                self.logger.debug(f"{file.rel_path}: {specifier} '{field}' set to {value}.")
+                specifier = "New field" if field in fields_to_be_created else "Field"
+                self.logger.debug(
+                    f"{file.rel_path}: {specifier} '{field}' set to {value}."
+                )
                 MSCX.metatags[field] = value
                 changed = True
             if remove_unused_fields:
@@ -1609,14 +1963,20 @@ class Piece(LoggedClass):
                         continue
                     staff_id = m.group(1)
                     if pd.isnull(value):
-                        self.logger.warning(f"{file.full_path}: Instrumentation for staff {staff_id} is empty.")
+                        self.logger.warning(
+                            f"{file.full_path}: Instrumentation for staff {staff_id} is empty."
+                        )
                     if value != current_values[staff_id]:
                         to_be_updated[staff_id] = value
                 if len(to_be_updated) > 0:
                     changed = True
-                    self.logger.debug(f"This instrumentation will be written into the score:\n{to_be_updated}")
+                    self.logger.debug(
+                        f"This instrumentation will be written into the score:\n{to_be_updated}"
+                    )
                     for staff, instrument in to_be_updated.items():
-                        self.logger.debug(f"{staff}: {current_values[staff]} => {instrument}")
+                        self.logger.debug(
+                            f"{staff}: {current_values[staff]} => {instrument}"
+                        )
                         MSCX.instrumentation.set_instrument(staff, instrument)
             if changed:
                 MSCX.update_metadata()
@@ -1626,17 +1986,18 @@ class Piece(LoggedClass):
                 self.logger.debug(f"No metadata need updating in {file.rel_path}")
         return updated_scores
 
-    def update_tsvs_on_disk(self,
-                       facets: ScoreFacets = 'tsv',
-                       view_name: Optional[str] = None,
-                       force: bool = False,
-                       choose: Literal['auto', 'ask'] = 'auto',
-                       ) -> List[str]:
+    def update_tsvs_on_disk(
+        self,
+        facets: ScoreFacets = "tsv",
+        view_name: Optional[str] = None,
+        force: bool = False,
+        choose: Literal["auto", "ask"] = "auto",
+    ) -> List[str]:
         """
-        Update existing TSV files corresponding to one or several facets with information freshly extracted from a parsed
-        score, but only if the contents are identical. Otherwise, the existing TSV file is not overwritten and the
-        differences are displayed in a log warning. The purpose is to safely update the format of existing TSV files,
-        (for instance with respect to column order) making sure that the content doesn't change.
+        Update existing TSV files corresponding to one or several facets with information freshly extracted from a
+        parsed score, but only if the contents are identical. Otherwise, the existing TSV file is not overwritten and
+        the differences are displayed in a log warning. The purpose is to safely update the format of existing TSV
+        files, (for instance with respect to column order) making sure that the content doesn't change.
 
         Args:
           facets:
@@ -1651,28 +2012,31 @@ class Piece(LoggedClass):
         """
         selected_facets = resolve_facets_param(facets, ScoreFacet, logger=self.logger)
         assert selected_facets is not None, f"Pass a valid facet {ScoreFacet.__args__}"
-        assert choose != 'all', "This method does not accept choose='all'."
+        assert choose != "all", "This method does not accept choose='all'."
         written_paths = []
-        parsed_tsvs = self.get_all_parsed(selected_facets,
-                                          view_name=view_name,
-                                          force=force,
-                                          choose=choose)
+        parsed_tsvs = self.get_all_parsed(
+            selected_facets, view_name=view_name, force=force, choose=choose
+        )
         if len(parsed_tsvs) == 0:
-            self.logger.info(f"No parsed TSV files to update.")
+            self.logger.info("No parsed TSV files to update.")
             return []
-        score_file, score_obj = self.get_parsed_score(view_name=view_name,
-                                             choose=choose
-                                             )
+        score_file, score_obj = self.get_parsed_score(
+            view_name=view_name, choose=choose
+        )
         if score_obj is None:
-            self.logger.info(f"This method updates TSV files based on a score but the current view includes none.")
+            self.logger.info(
+                "This method updates TSV files based on a score but the current view includes none."
+            )
             return []
         for facet, file_df_tuples in parsed_tsvs.items():
             if len(file_df_tuples) > 1:
-                self.logger.warning(f"There are more than one TSV files containing {facet} and they will be compared with "
-                                    f"the same score.")
-            score_file, new_df = self.extract_facet(facet,
-                                                    view_name=view_name,
-                                                    choose=choose)
+                self.logger.warning(
+                    f"There are more than one TSV files containing {facet} and they will be compared with "
+                    f"the same score."
+                )
+            score_file, new_df = self.extract_facet(
+                facet, view_name=view_name, choose=choose
+            )
             for tsv_file, old_df in file_df_tuples:
                 try:
                     # missing_columns = [c for c in old_df.columns if c not in new_df.columns]
@@ -1680,22 +2044,26 @@ class Piece(LoggedClass):
                     #     plural = 'These columns are' if len(missing_columns) > 1 else 'This column is'
                     #     self.logger.warning(f"{plural} missing in the updated {facet}:\n{old_df[missing_columns]}")
                     # tmp_new = new_df[[c for c in old_df.columns if c in new_df.columns]]
-                    # assert_frame_equal(old_df, tmp_new, check_dtype=False, obj=facet) # from pandas.testing import assert_frame_equal
+                    # assert_frame_equal(old_df, tmp_new, check_dtype=False, obj=facet) # from pandas.testing import
+                    # assert_frame_equal
                     assert_dfs_equal(old_df, new_df)
                     # TODO: make utils.assert_dfs_equal() use math.isclose() for comparing floats
                 except AssertionError as e:
-                    if facet == 'expanded':
-                        facet += ' labels'
-                    self.logger.warning(f"The {facet} extracted from {score_file.rel_path} is not identical with the "
-                                        f"ones in {tsv_file.rel_path}:\n{e}")
+                    if facet == "expanded":
+                        facet += " labels"
+                    self.logger.warning(
+                        f"The {facet} extracted from {score_file.rel_path} is not identical with the "
+                        f"ones in {tsv_file.rel_path}:\n{e}"
+                    )
                     continue
                 write_tsv(new_df, tsv_file.full_path, logger=self.logger)
                 written_paths.append(tsv_file.full_path)
         return written_paths
 
-
     def get_dataframe(self, *args, **kwargs) -> None:
         """Deprecated method. Replaced by :meth:`get_parsed`, :meth:`extract_facet`, and :meth:`get_facet()`."""
-        raise DeprecationWarning(f"Method not in use any more. Use _.get_parsed() to retrieve a parsed TSV file, "
-                             f"_.extract_facet() to retrieve a freshly extracted DataFrame, "
-                             f"or _.get_facet() to retrieve either, according to availability.")
+        raise DeprecationWarning(
+            "Method not in use any more. Use _.get_parsed() to retrieve a parsed TSV file, "
+            "_.extract_facet() to retrieve a freshly extracted DataFrame, "
+            "or _.get_facet() to retrieve either, according to availability."
+        )

--- a/src/ms3/score.py
+++ b/src/ms3/score.py
@@ -476,13 +476,11 @@ class MSCX(LoggedClass):
         self,
         all_endings: bool = False,
         unfold: bool = False,
-        negative_anacrusis: bool = False,
     ) -> dict:
         """{mc -> offset} dictionary measuring each MC's distance from the piece's beginning (0) in quarter notes."""
         return self.parsed.offset_dict(
             all_endings=all_endings,
             unfold=unfold,
-            negative_anacrusis=negative_anacrusis,
         )
 
     @property

--- a/src/ms3/score.py
+++ b/src/ms3/score.py
@@ -338,15 +338,22 @@ class MSCX(LoggedClass):
             expanded = unfolded_expanded
 
         has_chord = expanded.chord.notna()
+        offset_dict_all_endings = self.offset_dict(all_endings=True)
         if not has_chord.all():
             # Compute duration_qb for chord spans without interruption by other labels, such as phrase and
             # cadence labels, which are considered to have duration 0 and not interrupt the prevailing chord
             offset_dict = self.offset_dict(unfold=unfold)
             with_chord = add_quarterbeats_col(
-                expanded[has_chord], offset_dict, logger=self.logger
+                expanded[has_chord],
+                offset_dict=offset_dict,
+                offset_dict_all_endings=offset_dict_all_endings,
+                logger=self.logger,
             )
             without_chord = add_quarterbeats_col(
-                expanded[~has_chord], offset_dict, logger=self.logger
+                expanded[~has_chord],
+                offset_dict=offset_dict,
+                offset_dict_all_endings=offset_dict_all_endings,
+                logger=self.logger,
             )
             without_chord.duration_qb = 0.0
             expanded = pd.concat([with_chord, without_chord]).sort_index()
@@ -355,7 +362,8 @@ class MSCX(LoggedClass):
         else:
             expanded = add_quarterbeats_col(
                 expanded,
-                self.offset_dict(unfold=unfold),
+                offset_dict=self.offset_dict(unfold=unfold),
+                offset_dict_all_endings=self.offset_dict(all_endings=True),
                 interval_index=interval_index,
                 logger=self.logger,
             )
@@ -450,7 +458,8 @@ class MSCX(LoggedClass):
                 return
         labels = add_quarterbeats_col(
             labels,
-            self.offset_dict(unfold=unfold),
+            offset_dict=self.offset_dict(unfold=unfold),
+            offset_dict_all_endings=self.offset_dict(all_endings=True),
             interval_index=interval_index,
             logger=self.logger,
         )
@@ -2086,7 +2095,8 @@ class Score(LoggedClass):
             else:
                 labels = add_quarterbeats_col(
                     labels,
-                    self.mscx.offset_dict(unfold=unfold),
+                    offset_dict=self.mscx.offset_dict(unfold=unfold),
+                    offset_dict_all_endings=self.mscx.offset_dict(all_endings=True),
                     interval_index=interval_index,
                     logger=self.logger,
                 )

--- a/src/ms3/transformations.py
+++ b/src/ms3/transformations.py
@@ -75,30 +75,32 @@ def make_note_name_and_octave_columns(
 
 def add_quarterbeats_col(
     df: pd.DataFrame,
-    offset_dict: Union[pd.Series, dict],
+    offset_dict: pd.Series | dict,
     interval_index: bool = False,
+    name: Optional[str] = None,
     logger=None,
 ) -> pd.DataFrame:
     """Insert a column measuring the distance of events from MC 1 in quarter notes. If no 'mc_onset' column is present,
         the column corresponds to the values given in the offset_dict.
 
-    Parameters
-    ----------
-    df : :obj:`pandas.DataFrame`
-        DataFrame with an ``mc`` or ``mc_playthrough`` column, and an ``mc_onset`` column.
-    offset_dict : :obj:`pandas.Series` or :obj:`dict`, optional
-        | If unfolded: {mc_playthrough -> offset}
-        | Otherwise: {mc -> offset}
-        | You can create the dict using the functions make_continuous_offset_series() or
-          make_offset_dict_from_measures().
-        | It is not required if the column 'quarterbeats' exists already.
-    interval_index : :obj:`bool`, optional
-        Defaults to False. Pass True to replace the index with an :obj:`pandas.IntervalIndex` (depends on the successful
-        creation of the column ``duration_qb``).
+    Args:
+        df: DataFrame with an ``mc`` or ``mc_playthrough`` column, and an ``mc_onset`` column.
+        offset_dict:
+            | If unfolded: {mc_playthrough -> offset}
+            | Otherwise: {mc -> offset}
+            | You can create the dict using the functions make_continuous_offset_series() or
+              make_offset_dict_from_measures().
+            | It is not required if the column 'quarterbeats' exists already.
+        interval_index:
+            Defaults to False. Pass True to replace the index with an :obj:`pandas.IntervalIndex` (depends on the
+            successful creation of the column ``duration_qb``).
+        name:
+            If specified, name of the added column. Defaults to 'quarterbeats' for normal, and
+            'quarterbeats_playthrough' for unfolded dataframes.
+        logger:
 
-    Returns
-    -------
-
+    Returns:
+        The DataFrame with quarterbeats and duration_qb columns added.
     """
     if logger is None:
         logger = module_logger
@@ -153,13 +155,18 @@ def add_quarterbeats_col(
                 "Expected to have at least one column called 'mc' or 'mc_playthrough'."
             )
             return df
+        if name is None:
+            name = qb_column_name
         mc_column = df[mc_col]
         if "mc_onset" in df.columns:
             mc_onset_column = df.mc_onset
         else:
             mc_onset_column = None
         new_cols["quarterbeats"] = make_quarterbeats_column(
-            mc_column, mc_onset_column, offset_dict, qb_column_name
+            mc_column=mc_column,
+            mc_onset_column=mc_onset_column,
+            offset_dict=offset_dict,
+            name=name,
         )
     if not has_quarterbeats or not has_duration_qb:
         # recreate duration_qb also when quarterbeats had been missing

--- a/src/ms3/transformations.py
+++ b/src/ms3/transformations.py
@@ -89,8 +89,8 @@ def add_quarterbeats_col(
     offset_dict : :obj:`pandas.Series` or :obj:`dict`, optional
         | If unfolded: {mc_playthrough -> offset}
         | Otherwise: {mc -> offset}
-        | You can create the dict using the function :py:meth:`Parse.get_continuous_offsets(
-          )<ms3.parse.Parse.get_continuous_offsets>`
+        | You can create the dict using the functions make_continuous_offset_series() or
+          make_offset_dict_from_measures().
         | It is not required if the column 'quarterbeats' exists already.
     interval_index : :obj:`bool`, optional
         Defaults to False. Pass True to replace the index with an :obj:`pandas.IntervalIndex` (depends on the successful
@@ -144,8 +144,10 @@ def add_quarterbeats_col(
     if not has_quarterbeats:
         if "mc_playthrough" in df.columns:
             mc_col = "mc_playthrough"
+            qb_column_name = "quarterbeats_playthrough"
         elif "mc" in df.columns:
             mc_col = "mc"
+            qb_column_name = "quarterbeats"
         else:
             logger.error(
                 "Expected to have at least one column called 'mc' or 'mc_playthrough'."
@@ -154,7 +156,7 @@ def add_quarterbeats_col(
         quarterbeats = df[mc_col].map(offset_dict)
         if "mc_onset" in df.columns:
             quarterbeats += df.mc_onset * 4
-        new_cols["quarterbeats"] = quarterbeats.rename("quarterbeats")
+        new_cols["quarterbeats"] = quarterbeats.rename(qb_column_name)
     if not has_quarterbeats or not has_duration_qb:
         # recreate duration_qb also when quarterbeats had been missing
         if "duration" in df.columns:

--- a/src/ms3/utils/frictionless_helpers.py
+++ b/src/ms3/utils/frictionless_helpers.py
@@ -96,8 +96,8 @@ def column_name2frictionless_field(column_name) -> dict:
 
 
 def make_frictionless_schema_descriptor(
-    column_names: Tuple[str, ...],
-    primary_key: Optional[Tuple[str, ...]] = None,
+    column_names: Iterable[str],
+    primary_key: Optional[Iterable[str]] = None,
     **custom_data,
 ) -> dict:
     fields = []
@@ -116,7 +116,7 @@ def make_frictionless_schema_descriptor(
         fields.append(field)
     descriptor = dict(fields=fields)
     if primary_key:
-        descriptor["primaryKey"] = primary_key
+        descriptor["primaryKey"] = list(primary_key)
     if len(custom_data) > 0:
         descriptor.update(custom_data)
     return descriptor

--- a/src/ms3/utils/frictionless_helpers.py
+++ b/src/ms3/utils/frictionless_helpers.py
@@ -204,7 +204,8 @@ def get_schema_or_url(
     column_names: Tuple[str],
     index_levels: Optional[Tuple[str]] = None,
     base_local_path=SCHEMAS_DIR,
-    base_url="https://raw.githubusercontent.com/johentsch/ms3/main/schemas/",
+    base_url="https://raw.githubusercontent.com/DCMLab/frictionless_schemas/main/",
+    # "https://raw.githubusercontent.com/johentsch/ms3/main/schemas/"
 ) -> str | dict:
     """Given a facet name (=subfolder) and a tuple of [index column names +] column names, compute an identifier and
     if that schema exists under ``<base_url>/<facet>/<identifier>.schema.yaml`` return that URL, or otherwise

--- a/src/ms3/utils/frictionless_helpers.py
+++ b/src/ms3/utils/frictionless_helpers.py
@@ -170,7 +170,9 @@ def make_json_path(file: File) -> str:
 
 
 UTILS_DIR = os.path.dirname(__file__)  # .../ms3/src/ms3/utils/
-SCHEMAS_DIR = os.path.normpath(os.path.join(UTILS_DIR, "..", "..", "..", "schemas"))
+SCHEMAS_DIR = os.path.normpath(
+    os.path.join(UTILS_DIR, "..", "..", "..", "frictionless_schemas")
+)
 os.makedirs(SCHEMAS_DIR, exist_ok=True)
 
 

--- a/src/ms3/utils/frictionless_helpers.py
+++ b/src/ms3/utils/frictionless_helpers.py
@@ -40,7 +40,9 @@ FIELDS_WITHOUT_MISSING_VALUES = (
     "mc_playthrough",
 )
 FRACTION_REGEX = r"\d+(?:\/\d+)?"  # r"-?\d+(?:\/\d+)?" for including negative fractions
-INT_ARRAY_REGEX = r"^[([]?(?:-?\d+\s*,?\s*)*[])]?$"
+INT_ARRAY_REGEX = r"^[([]?(?:-?\d+\s*,?\s*)*[])]?$"  # allows any number of integers, separated by a comma and/or
+# whitespace, and optionally enclosed in parentheses or square brackets
+EDTF_LIKE_YEAR_REGEX = r"^\d{3,4}|\.{2}$"
 
 
 @cache
@@ -66,8 +68,14 @@ def column_name2frictionless_field(column_name) -> dict:
             field["type"] = "string"
             constraints["pattern"] = FRACTION_REGEX
         elif string_converter == safe_int:
-            field["type"] = "integer"
-            field["bareNumber"] = False  # allow other leading and trailing characters
+            if column_name in ("composed_start", "composed_end"):
+                field["type"] = "string"
+                constraints["pattern"] = EDTF_LIKE_YEAR_REGEX
+            else:
+                field["type"] = "integer"
+                field[
+                    "bareNumber"
+                ] = False  # allow other leading and trailing characters
         elif string_converter == str2inttuple:
             field["type"] = "string"
             constraints["pattern"] = INT_ARRAY_REGEX

--- a/tests/test_local_files/ALL_WARNINGS
+++ b/tests/test_local_files/ALL_WARNINGS
@@ -1,45 +1,181 @@
-VOLTAS_WITH_DIFFERING_LENGTHS_WARNING (4, 19) ms3.Parse.old_tests.D973deutscher01 -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 780) treat_group():
-	Volta group of MC 19 contains voltas with different lengths: [1, 2] Check for correct computation of MNs.
-COMPETING_MEASURE_INFO_WARNING (9, 'mc', 1, 'voice/KeySig/accidental') ms3.Parse.old_tests.05_symph_fant -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 577) squash_staves():
-	mc 1: The values ['3' '2'] in 'voice/KeySig/accidental' of 
-	 'staff' [4, 11] are lost.
-VOLTAS_WITH_DIFFERING_LENGTHS_WARNING (4, 93) ms3.Parse.old_tests.BWV_0815 -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 780) treat_group():
-	Volta group of MC 93 contains voltas with different lengths: [1, 2, 1] Check for correct computation of MNs.
-VOLTAS_WITH_DIFFERING_LENGTHS_WARNING (4, 128) ms3.Parse.old_tests.BWV_0815 -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 780) treat_group():
-	Volta group of MC 128 contains voltas with different lengths: [1, 2] Check for correct computation of MNs.
-MISSING_END_REPEAT_WARNING (5, 97) ms3.Parse.old_tests.BWV_0815 -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 391) start_section():
-	The startRepeat in MC 97 is missing its endRepeat.
-	For correction, MC 111 is interpreted as such because it precedes the next startRepeat.
-INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 111) ms3.Parse.old_tests.BWV_0815 -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 707) make_offset_col():
-	The incomplete MC 111 (timesig 1, act_dur 1/2) is completed by 1 incorrect duration (expected: 1/2):
-	{97: Fraction(1, 2), 112: Fraction(3, 4)}
-INCORRECT_VOLTA_MN_WARNING (2, 96) ms3.Parse.old_tests.BWV_0815 -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 184) check_measure_numbers():
-	MC 96, the 1st measure of a 3rd volta, should have MN 113, not MN 115.
-INCORRECT_VOLTA_MN_WARNING (2, 120) ms3.Parse.old_tests.BWV_0815 -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 184) check_measure_numbers():
-	MC 120, the 1st measure of a 2nd volta, should have MN 138, not MN 139.
-INCORRECT_VOLTA_MN_WARNING (2, 129) ms3.Parse.old_tests.BWV_0815 -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 184) check_measure_numbers():
-	MC 129, the 1st measure of a 2nd volta, should have MN 147, not MN 148.
-INCORRECT_VOLTA_MN_WARNING (2, 138) ms3.Parse.old_tests.BWV_0815 -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 184) check_measure_numbers():
-	MC 138, the 1st measure of a 2nd volta, should have MN 156, not MN 157.
-MCS_NOT_EXCLUDED_FROM_BARCOUNT_WARNING (1, 1, 40, 85, 97, 131, 139) ms3.Parse.old_tests.BWV_0815 -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 197) check_measure_numbers():
-	MCs 1, 40, 85, 97, 131, 139 seem to be offset from the MN's beginning but have not been excluded from barcount. Context:
-	      mc   mn act_dur mc_offset  dont_count  numbering_offset
-	0      1    1    1/16     15/16        <NA>              <NA>
-	1      2    2       1         0        <NA>              <NA>
-	38    39   59     5/8         0        <NA>              <NA>
-	39    40   60     1/8       5/8        <NA>              <NA>
-	40    41   61     3/4         0        <NA>              <NA>
-	83    84  104     3/4         0        <NA>              <NA>
-	84    85  105     1/2       1/2        <NA>              <NA>
-	85    86  106       1         0        <NA>              <NA>
-	95    96  115     1/2         0        <NA>              <NA>
-	96    97  116     1/2       1/2        <NA>              <NA>
-	97    98  117       1         0        <NA>              <NA>
-	129  130  149     1/4         0        <NA>              <NA>
-	130  131  150     1/2       1/2        <NA>              <NA>
-	131  132  151       1         0        <NA>              <NA>
-	137  138  157     1/2         0        <NA>              <NA>
-	138  139  158     1/2       1/2        <NA>              <NA>
-	139  140  159       1         0        <NA>              <NA>
-INCORRECT_VOLTA_MN_WARNING (2, 94) ms3.Parse.old_tests.Did03M-Son_regina-1762-Sarti -- /home/hentsche/PycharmProjects/ms3/src/ms3/bs4_measures.py (line 184) check_measure_numbers():
-	MC 94, the 1st measure of a 2nd volta, should have MN 93, not MN 94.
+FIRST_BAR_MISSING_TEMPO_MARK_WARNING (29,) ms3.Parse.ravel_piano.Ravel_-_Jeux_dEau -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_parser.py (line 2846) perform_checks():
+        No metronome mark found in the very first measure nor anywhere else in the score.
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 17) ms3.Parse.ravel_piano.Ravel_-_Miroirs_II_Oiseaux_tristes -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413)
+which_mcs_to_offset():
+        None of the MCs following the irregular MC 17 complete it.
+           nominal_duration actual_duration expected_completion   next
+        mc
+        17                1            9/16                7/16  (18,)
+        18                1             1/2                 1/2  (19,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 18) ms3.Parse.ravel_piano.Ravel_-_Miroirs_II_Oiseaux_tristes -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413)
+which_mcs_to_offset():
+        None of the MCs following the irregular MC 18 complete it.
+           nominal_duration actual_duration expected_completion   next
+        mc
+        18                1             1/2                 1/2  (19,)
+        19                1             1/4                 3/4  (20,)
+MCS_NOT_EXCLUDED_FROM_BARCOUNT_WARNING (1, 14, 16, 20, 25, 28) ms3.Parse.ravel_piano.Ravel_-_Miroirs_II_Oiseaux_tristes -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 890) check_measure_numbers():
+        MCs 14, 16, 20, 25, 28 seem to be offset from the MN's beginning but have not been excluded from barcount. Context:
+            mc  mn act_dur mc_offset  dont_count  numbering_offset
+        12  13  13     1/2         0        <NA>              <NA>
+        13  14  14     1/2       1/2        <NA>              <NA>
+        14  15  15     1/2         0        <NA>              <NA>
+        15  16  16     1/2       1/2        <NA>              <NA>
+        16  17  17    9/16         0        <NA>              <NA>
+        18  19  19     1/4         0        <NA>              <NA>
+        19  20  20     3/4       1/4        <NA>              <NA>
+        20  21  21       1         0        <NA>              <NA>
+        23  24  24     1/2         0        <NA>              <NA>
+        24  25  25     1/2       1/2        <NA>              <NA>
+        25  26  26       1         0        <NA>              <NA>
+        26  27  27     1/2         0        <NA>              <NA>
+        27  28  28     1/2       1/2        <NA>              <NA>
+        28  29  29       1         0        <NA>              <NA>
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 13) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 13 complete it.
+           nominal_duration actual_duration expected_completion   next
+        mc
+        13              3/4             1/4                 1/2  (14,)
+        14              3/4             5/8                 1/8  (15,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 14) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 14 complete it.
+           nominal_duration actual_duration expected_completion   next
+        mc
+        14              3/4             5/8                 1/8  (15,)
+        15              1/2             1/2                   0  (16,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 25) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 25 complete it.
+           nominal_duration actual_duration expected_completion   next
+        mc
+        25              3/4             1/4                 1/2  (26,)
+        26              3/4             5/8                 1/8  (27,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 26) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 26 complete it.
+           nominal_duration actual_duration expected_completion   next
+        mc
+        26              3/4             5/8                 1/8  (27,)
+        27              1/2             1/2                   0  (28,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 45) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 45 complete it.
+           nominal_duration actual_duration expected_completion   next
+        mc
+        45                1             3/4                 1/4  (46,)
+        46                1             3/8                 5/8  (47,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 46) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 46 complete it.
+           nominal_duration actual_duration expected_completion   next
+        mc
+        46                1             3/8                 5/8  (47,)
+        47              3/4             3/4                   0  (48,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 48) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 48 complete it.
+           nominal_duration actual_duration expected_completion   next
+        mc
+        48                1             3/4                 1/4  (49,)
+        49                1             3/8                 5/8  (50,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 49) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 49 complete it.
+           nominal_duration actual_duration expected_completion   next
+        mc
+        49                1             3/8                 5/8  (50,)
+        50                1             3/4                 1/4  (51,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 50) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 50 complete it.
+           nominal_duration actual_duration expected_completion   next
+        mc
+        50                1             3/4                 1/4  (51,)
+        51              5/4             3/4                 1/2  (52,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 104) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 104 complete it.
+            nominal_duration actual_duration expected_completion    next
+        mc
+        104                1             3/4                 1/4  (105,)
+        105                1             3/4                 1/4  (106,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 105) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 105 complete it.
+            nominal_duration actual_duration expected_completion    next
+        mc
+        105                1             3/4                 1/4  (106,)
+        106                1             3/4                 1/4  (107,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 106) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 106 complete it.
+            nominal_duration actual_duration expected_completion    next
+        mc
+        106                1             3/4                 1/4  (107,)
+        107                1               1                   0  (108,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 147) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 147 complete it.
+            nominal_duration actual_duration expected_completion    next
+        mc
+        147              3/4             1/2                 1/4  (148,)
+        148              3/4             1/2                 1/4  (149,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 148) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 148 complete it.
+            nominal_duration actual_duration expected_completion    next
+        mc
+        148              3/4             1/2                 1/4  (149,)
+        149              3/4             5/8                 1/8  (150,)
+INCOMPLETE_MC_WRONGLY_COMPLETED_WARNING (3, 149) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 413) which_mcs_to_offset():
+        None of the MCs following the irregular MC 149 complete it.
+            nominal_duration actual_duration expected_completion    next
+        mc
+        149              3/4             5/8                 1/8  (150,)
+        150              3/4             3/4                   0  (151,)
+MCS_NOT_EXCLUDED_FROM_BARCOUNT_WARNING (1, 6, 18, 35, 43, 52, 79, 84, 102) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_measures.py (line 890) check_measure_numbers():
+        MCs 6, 18, 35, 43, 52, 79, 84, 102 seem to be offset from the MN's beginning but have not been excluded from barcount. Context:
+              mc   mn act_dur mc_offset  dont_count  numbering_offset
+        4      5    5     1/4         0        <NA>              <NA>
+        5      6    6     1/4       1/4        <NA>              <NA>
+        6      7    7     1/2         0        <NA>              <NA>
+        16    17   17     1/4         0        <NA>              <NA>
+        17    18   18     1/4       1/4        <NA>              <NA>
+        18    19   19     1/2         0        <NA>              <NA>
+        33    34   34     1/4         0        <NA>              <NA>
+        34    35   35     1/2       1/4        <NA>              <NA>
+        35    36   36     3/4         0        <NA>              <NA>
+        41    42   42     1/2         0        <NA>              <NA>
+        42    43   43     1/4       1/2        <NA>              <NA>
+        43    44   44     3/4         0        <NA>              <NA>
+        50    51   51     3/4         0        <NA>              <NA>
+        51    52   52     1/2       3/4        <NA>              <NA>
+        52    53   53     1/2         0        <NA>              <NA>
+        77    78   78     3/4         0        <NA>              <NA>
+        78    79   79     1/4       3/4        <NA>              <NA>
+        79    80   80     3/4         0        <NA>              <NA>
+        82    83   83     3/4         0        <NA>              <NA>
+        83    84   84     1/2       3/4        <NA>              <NA>
+        84    85   85     1/2         0        <NA>              <NA>
+        100  101  101     1/2         0        <NA>              <NA>
+        101  102  102     1/2       1/2        <NA>              <NA>
+        102  103  103       1         0        <NA>              <NA>
+FIRST_BAR_MISSING_TEMPO_MARK_WARNING (29,) ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_parser.py (line 2846) perform_checks():
+        No metronome mark found in the very first measure nor anywhere else in the score.
+FIRST_BAR_MISSING_TEMPO_MARK_WARNING (29,) ms3.Parse.ravel_piano.Ravel_-_Miroirs_IV_Alborada_del_gracioso -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_parser.py (line 2846) perform_checks():
+        No metronome mark found in the very first measure nor anywhere else in the score.
+INFO     ms3.Parse.ravel_piano -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\corpus.py (line 2002) parse_scores():
+        All 5 scores have been parsed successfully.
+FIRST_BAR_MISSING_TEMPO_MARK_WARNING (29,) ms3.Parse.sweelinck_keyboard.SwWV258_fantasia_cromatica -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\bs4_parser.py (line 2846) perform_checks():
+        No metronome mark found in the very first measure nor anywhere else in the score.
+INFO     ms3.Parse.sweelinck_keyboard -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\corpus.py (line 2002) parse_scores():
+        The score has been parsed successfully.
+INFO     ms3.Parse.wagner_overtures -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\corpus.py (line 2002) parse_scores():
+        All 2 scores have been parsed successfully.
+WARNING  ms3.check -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\operations.py (line 218) check():
+        Warnings detected while parsing scores (see above).
+DCML_HARMONY_SUPERFLUOUS_TONE_REPLACEMENT_WARNING (6, 142, 'V7(6b5)') ms3.Parse.ravel_piano.Ravel_-_Miroirs_III_Une_Barque_sur_l'ocean -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\utils\functions.py (line 5332) features2tpcs():
+        MC 142: V7(6b5) results in a chord tone 5th AND its replacement(s) (TPC [-3]). You might want to add a + to distinguish from a suspension, or add this warning to IGNORED_WARNINGS with a comment.
+DCML_HARMONY_SUPERFLUOUS_TONE_REPLACEMENT_WARNING (6, 7, 'V64(6b5)') ms3.Parse.wagner_overtures.WWV090_Tristan_01_Vorspiel-Prelude_Ricordi1888Floridia -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\utils\functions.py (line 5332) features2tpcs():
+        MC 7: V64(6b5) results in a chord tone 5th AND its replacement(s) (TPC [2]). You might want to add a + to distinguish from a suspension, or add this warning to IGNORED_WARNINGS with a comment.
+DCML_HARMONY_SUPERFLUOUS_TONE_REPLACEMENT_WARNING (6, 87, 'V64(6b5)') ms3.Parse.wagner_overtures.WWV090_Tristan_01_Vorspiel-Prelude_Ricordi1888Floridia -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\utils\functions.py (line 5332) features2tpcs():
+        MC 87: V64(6b5) results in a chord tone 5th AND its replacement(s) (TPC [2]). You might want to add a + to distinguish from a suspension, or add this warning to IGNORED_WARNINGS with a comment.
+DCML_HARMONY_SUPERFLUOUS_TONE_REPLACEMENT_WARNING (6, 106, 'V64(6b5)') ms3.Parse.wagner_overtures.WWV090_Tristan_01_Vorspiel-Prelude_Ricordi1888Floridia -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\utils\functions.py (line 5332) features2tpcs():
+        MC 106: V64(6b5) results in a chord tone 5th AND its replacement(s) (TPC [5]). You might want to add a + to distinguish from a suspension, or add this warning to IGNORED_WARNINGS with a comment.
+DCML_HARMONY_SUPERFLUOUS_TONE_REPLACEMENT_WARNING (6, 71, 'V64(6b5)') ms3.Parse.wagner_overtures.WWV090_Tristan_01_Vorspiel-Prelude_Ricordi1888Floridia -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\utils\functions.py (line 5332) features2tpcs():
+        MC 71: V64(6b5) results in a chord tone 5th AND its replacement(s) (TPC [2]). You might want to add a + to distinguish from a suspension, or add this warning to IGNORED_WARNINGS with a comment.
+WRONGLY_ENCODED_POSITION_WARNING (28,) ms3.Parse.wagner_overtures.WWV090_Tristan_01_Vorspiel-Prelude_Ricordi1888Floridia -- c:\users\hentsche\pycharmprojects\ms3\src\ms3\transformations.py (line 211) add_quarterbeats_col():
+        In the following instances the second event occurs before the first one:
+                       mc  mn mc_onset mn_onset timesig  staff  voice      label alt_label globalkey localkey pedal
+        problem index
+        0       284    84  83      5/8      5/8     6/8      2      1  V43(b5)/V      <NA>         a        i   NaN
+                285    85  84     -1/4     -1/4     6/8      2      1         V7      <NA>         a        i   NaN
+        Each second row will not have a 'duration_qb' value.

--- a/tests/test_local_files/test_score_object.py
+++ b/tests/test_local_files/test_score_object.py
@@ -115,29 +115,21 @@ class TestScore:
                 tmp_file.close()
                 os.remove(tmp_file.name)
 
-    def test_expanded_labels(self, score_object):
+    def test_expanded_labels(
+        self,
+        score_object,
+        tmp_path,
+    ):
         if score_object.mscx.has_annotations:
             piece_name = score_object.fnames["mscx"] + ".labels.tsv"
             target_path = os.path.join(self.test_results, piece_name)
+            tmp_filepath = str(tmp_path / piece_name)
             target_labels = decode_harmonies(load_tsv(target_path))
-            try:
-                extracted_labels = no_collections_no_booleans(
-                    score_object.mscx.labels()
-                )
-                with tempfile.NamedTemporaryFile(
-                    mode="r+",
-                    suffix=".tsv",
-                    dir=self.test_folder,
-                    encoding="utf-8",
-                    delete=False,
-                ) as tmp_file:
-                    extracted_labels.to_csv(tmp_file, sep="\t", index=False)
-                    new_path = tmp_file.name
-                new_labels = load_tsv(new_path)
-                assert len(new_labels) > 0
-                assert_dfs_equal(target_labels, new_labels)
-            finally:
-                os.remove(tmp_file.name)
+            extracted_labels = no_collections_no_booleans(score_object.mscx.labels())
+            extracted_labels.to_csv(tmp_filepath, sep="\t", index=False)
+            new_labels = load_tsv(tmp_filepath)
+            assert len(new_labels) > 0
+            assert_dfs_equal(target_labels, new_labels)
 
     def test_mc_offset(self, score_object, target_measures_table):
         target_mc_offset = target_measures_table["mc_offset"]

--- a/tests/test_metarepo_files/debugging.py
+++ b/tests/test_metarepo_files/debugging.py
@@ -6,9 +6,13 @@ This script contains functions for the mere purpose of triggering a particular a
 debugger. Feel free to add functions and to hardcode paths to your system since this is an auxiliary file where,
 the moment something is considered, it is considered obsolete.
 """
+import os.path
 
 from ms3 import Parse
 from ms3.logger import get_logger
+from ms3.operations import transform_to_resources
+
+CORPUS_PATH = r"C:\Users\hentsche\baroque_keyboard_corpus\bach_en_fr_suites"
 
 
 def ignoring_warning():
@@ -22,15 +26,14 @@ def ignoring_warning():
     _ = p.get_dataframes(expanded=True)
 
 
-def extraction():
-    """Created by executing an ms3 command and coping the object initializing from the output."""
+def parse_object() -> Parse:
     p = Parse(
-        r"C:\Users\hentsche\all_subcorpora\liszt_pelerinage",
+        CORPUS_PATH,
         recursive=True,
         only_metadata_pieces=True,
         include_convertible=False,
         exclude_review=True,
-        file_re="160.06",
+        file_re=None,
         folder_re=None,
         exclude_re=None,
         file_paths=None,
@@ -38,8 +41,27 @@ def extraction():
         ms=None,
         **{"level": "i", "path": None}
     )
+    p.info()
+    return p
+
+
+def extraction():
+    """Created by executing an ms3 command and coping the object initializing from the output."""
+    p = parse_object()
     p.parse_scores()
 
 
+def transform_cmd():
+    p = parse_object()
+    p.parse_tsv()
+    output_folder, filename = os.path.split(CORPUS_PATH)
+    transform_to_resources(
+        ms3_object=p,
+        facets="metadata",
+        filename=filename,
+        output_folder=output_folder,
+    )
+
+
 if __name__ == "__main__":
-    extraction()
+    transform_cmd()

--- a/tests/test_metarepo_files/test_parse.py
+++ b/tests/test_metarepo_files/test_parse.py
@@ -55,8 +55,8 @@ class TestLogging:
         with capture_parse_logs(b.logger) as captured_msgs:
             b.parse_scores(parallel=True)
             parallel_msgs = captured_msgs.content_list
-        for msg in non_parallel_msgs:
-            assert msg in parallel_msgs
+        not_captured = [msg for msg in non_parallel_msgs if msg not in parallel_msgs]
+        assert len(not_captured) == 0
 
     def test_default(self, small_directory):
         p = Parse(small_directory)
@@ -135,7 +135,7 @@ class TestLogging:
             p.parse()
             _ = p.get_dataframes(expanded=True)
             all_msgs = captured_msgs.content_list
-        assert len(all_msgs) == 0
+        assert all_msgs == []
 
     def test_capturing_suppressed_warnings(
         self, get_all_warnings, get_all_supressed_warnings


### PR DESCRIPTION
* All facets now come with an additional `quarterbeats_all_endings` column that does not exclude first, and third endings from the computation of quarterbeats. The main purpose of this column is score addressability. Whereas the `quarterbeats` column (already included by default) is an attempt at a "logical timeline" representing a single playthrough (rather than a full, "unfolded", playthrough with all repeats), this columns is the "printed timeline" for all score elements in the order in which they occur in the score, without taking into account logical non-succession in the case of alternative endings (voltas). c7ea76d...095c36f 
* In 'unfolded' facet dataframes that represent a full playthrough, the `quarterbeats` column will now be called `quarterbeats_playthrough` (it is computed using the `mc_playthrough` column) for matters of clarity. The new `quarterbeats_all_endings` column, on the other hand, always displays the same values based on the `mc`, no matter how often this MC is repeated. This enables score addressability for elements in unfolded dataframes, too. c7ea76d
* Frictionless schemas are now stored at [DCMLab/frictionless_schemas](https://github.com/DCMLab/frictionless_schemas/). This is achieved by including this repo as submodule and changing the `frictionless_helpers/SCHEMAS_DIR` constant. The "old" schemas will remain at https://github.com/johentsch/ms3/tree/main/schemas (and be included in every release's archive) until no dataframes "in production" refer to this address anymore, at which point they will be sunset.
* Does away with the creation of frictionless resource descriptors for `events` tables as justified in fee20c4
* Changes to frictionless schemas:
  * changes the dtype of `composed_start` and `composed_end` metadata columns to a string with a regex constraint allowing for 3- and 4-digit year numbers and `..` (adopted from the [Extended Date Time Format (EDTF)](https://www.loc.gov/standards/datetime/) standard). 4717749
  * schemas are now created with `used_in=piece_name` metadata, storing the first name of the first piece responsible for creating it. The purpose is traceability and inspection. b9f255a
* chords facet stripped of empty columns 2f38e40
* rests facets is `None` if no rests present in the score 12b8b07
* notes_and_rests facet corresponds to the one facet if the other is empty 12b8b07
* renames the column `metronome_visible` in chords facets to `tempo_visible` 4d4b9f9 