### PR TITLE
Adds 'ms3 precommit' and makes the repo usable as a hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: review
     name: Review annotated MuseScore files
     description: This hook is equivalent to running ms3 extract, ms3 check, and ms3 compare
-    entry: ms3 review --files
+    entry: ms3 precommit
     language: python
     files: \.(mscx|mscz)$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: review
+    name: Review annotated MuseScore files
+    description: This hook is equivalent to running ms3 extract, ms3 check, and ms3 compare
+    entry: ms3 review --files
+    language: python
+    files: \.(mscx|mscz)$

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/ms3/*

--- a/src/ms3/cli.py
+++ b/src/ms3/cli.py
@@ -1158,7 +1158,7 @@ def run():
         parser.print_help()
         return
     if args.files is not None:
-        args.files = [resolve_dir(path) for path in args.file]
+        args.files = [resolve_dir(path) for path in args.files]
     args.func(args)
 
 

--- a/src/ms3/cli.py
+++ b/src/ms3/cli.py
@@ -348,7 +348,7 @@ def precommit_cmd(
             "The --files argument should not be used for ms3 precommit which takes files as "
             "positional arguments."
         )
-    args.files = args.positional_args
+    args.files = args.positional_args  # in the future, maybe use args.include instead
     test_passes = review_cmd(args, parse_obj=parse_obj, wrapped_by_precommit=True)
     repo = git.Repo(args.dir)
     repo.git.add(all=True)
@@ -866,10 +866,11 @@ def get_arg_parser():
         metavar="GIT_REVISION",
         const="",
         help="Pass -c if you want the _reviewed file to display removed labels in red and added labels in green, "
-        "compared to the version currently "
-        "represented in the present TSV files, if any. If instead you want a comparison with the TSV files from "
-        "another Git commit, additionally "
-        "pass its specifier, e.g. 'HEAD~3', <branch-name>, <commit SHA> etc.",
+        "compared to the version currently represented in the present TSV files, if any. If instead you want a "
+        "comparison with the TSV files from another Git commit, additionally pass its specifier, e.g. 'HEAD~3', "
+        "<branch-name>, <commit SHA> etc. LATEST_VERSION is accepted as a revision specifier and will result in "
+        "a comparison with the TSV files at the tag with the highest version number (falling back to HEAD if no "
+        "tags  have been assigned to the repository.",
     )
     review_args.add_argument(
         "--threshold",
@@ -941,10 +942,11 @@ In particular, check DCML harmony labels for syntactic correctness.""",
         metavar="GIT_REVISION",
         default="",
         help="By default, the _reviewed file displays removed labels in red and added labels in green, compared to "
-        "the version currently "
-        "represented in the present TSV files, if any. If instead you want a comparison with the TSV files from "
-        "another Git commit, "
-        "pass its specifier, e.g. 'HEAD~3', <branch-name>, <commit SHA> etc.",
+        "the version currently represented in the present TSV files, if any. If instead you want a "
+        "comparison with the TSV files from another Git commit, additionally pass its specifier, e.g. 'HEAD~3', "
+        "<branch-name>, <commit SHA> etc. LATEST_VERSION is accepted as a revision specifier and will result in "
+        "a comparison with the TSV files at the tag with the highest version number (falling back to HEAD if no "
+        "tags  have been assigned to the repository.",
     )
     compare_parser.add_argument(
         "-s",

--- a/src/ms3/operations.py
+++ b/src/ms3/operations.py
@@ -276,7 +276,9 @@ def compare(
       revision_specifier:
           If None, no comparison is undertaken. Passing an empty string will result in a comparison with the parsed
           TSV files included in the current view (if any). Specifying a git revision will result in a comparison
-          with the TSV files at that commit.
+          with the TSV files at that commit. "LATEST_VERSION" is accepted as a revision specifier and will result in
+          a comparison with the TSV files at the tag with the highest version number (falling back to HEAD if no tags
+          have been assigned to the repository).
       flip:
 
     Returns:
@@ -293,11 +295,13 @@ def compare(
     choose = "ask" if ask else "auto"
     if revision_specifier is None:
         key = f"previous_{facet}"
+        metadata_update = None
         logger.info(
             f"Comparing annotations to those contained in the current '{facet}' TSV files..."
         )
     else:
         key = revision_specifier
+        metadata_update = dict(compared_against=revision_specifier)
         logger.info(
             f"Comparing annotations to those contained in the '{facet}' TSV files @ git revision "
             f"{revision_specifier}..."
@@ -310,7 +314,11 @@ def compare(
     logger.info(
         f"Comparisons to be performed:\n{pretty_dict(comparisons_per_corpus, 'Corpus', 'Comparisons')}"
     )
-    return parse_obj.compare_labels(key=key, detached_is_newer=flip)
+    return parse_obj.compare_labels(
+        key=key,
+        detached_is_newer=flip,
+        metadata_update=metadata_update,
+    )
 
 
 def store_scores(

--- a/src/ms3/parse.py
+++ b/src/ms3/parse.py
@@ -626,6 +626,7 @@ class Parse(LoggedClass):
         detached_is_newer: bool = False,
         add_to_rna: bool = True,
         view_name: Optional[str] = None,
+        metadata_update: Optional[dict] = None,
     ) -> Tuple[int, int]:
         """Compare detached labels ``key`` to the ones attached to the Score to create a diff.
         By default, the attached labels are considered as the reviewed version and labels that have changed or been
@@ -657,6 +658,7 @@ class Parse(LoggedClass):
                 detached_is_newer=detached_is_newer,
                 add_to_rna=add_to_rna,
                 view_name=view_name,
+                metadata_update=metadata_update,
             )
             changed += c
             unchanged += u

--- a/src/ms3/piece.py
+++ b/src/ms3/piece.py
@@ -601,6 +601,7 @@ class Piece(LoggedClass):
         detached_is_newer: bool = False,
         add_to_rna: bool = True,
         view_name: Optional[str] = None,
+        metadata_update: Optional[dict] = None,
     ) -> Tuple[int, int]:
         """Compare detached labels ``key`` to the ones attached to the Score to create a diff.
         By default, the attached labels are considered as the reviewed version and labels that have changed or been
@@ -632,6 +633,7 @@ class Piece(LoggedClass):
                     old_color=old_color,
                     detached_is_newer=detached_is_newer,
                     add_to_rna=add_to_rna,
+                    metadata_update=metadata_update,
                 )
                 if changes > (0, 0):
                     changed += 1

--- a/src/ms3/utils/functions.py
+++ b/src/ms3/utils/functions.py
@@ -6487,7 +6487,7 @@ def get_name_of_highest_version_tag(
 
 @cache
 def get_git_commit(
-    repo_path: str, git_revision: str, logger=None
+    repo_path: str, git_revision: Optional[str], logger=None
 ) -> Optional[git.Commit]:
     """Returns the git commit object for the given revision.
 
@@ -6511,9 +6511,11 @@ def get_git_commit(
         logger.error(f"{repo_path} is not an existing git repository: {e}")
         return
     if git_revision == "LATEST_VERSION":
-        git_revision = get_name_of_highest_version_tag(
-            repo, git_revision
-        )  # None if no tags; will resolve to HEAD
+        git_revision = get_name_of_highest_version_tag(repo)
+        if git_revision is None:
+            logger.error(
+                "Could not find the latest version tag, falling back to current HEAD."
+            )
     try:
         return repo.commit(git_revision)
     except BadName:
@@ -6524,7 +6526,7 @@ def get_git_commit(
 
 @cache
 def resolve_git_revision(
-    repo_path: str, git_revision: str, logger=None
+    repo_path: str, git_revision: Optional[str], logger=None
 ) -> Optional[str]:
     """Returns the commit hash for the given revision.
 
@@ -6532,7 +6534,8 @@ def resolve_git_revision(
         repo_path:
         git_revision:
             Any specifier that git understands (branch, tag, commit hash, "HEAD", etc.). In addition,
-            "LATEST_VERSION" can be passed to get the tag with the highest version number.
+            "LATEST_VERSION" can be passed to get the tag with the highest version number. None defaults
+            to "HEAD".
         logger:
 
     Returns:


### PR DESCRIPTION
The new `ms3 precommit` command is simply a wrapper around `ms3 review` that accepts the ``--files`` arguments as positional arguments. This is required for the command to be useable as an entry point for a [Git pre-commit](https://pre-commit.com/), which passes the paths of modified or added files as positional arguments. In addition, the command executes `git add -A` after the review so that all changed files are included.

This is to work in the first version of the new, localized, DCML annotation workflow that runs on the annotator's machine before committing, rather than on a GitHub runner after pushing. Things that might be changed in the future:

* The `ms3 precommit` command could convert the positional arguments into a regular expression to be passed to `-i/--include` instead of using the deprecated `--files`.
* At some point a mechanism might be needed that makes it possible for the hook to ignore warnings that were already there, i.e., which are not caused/added by the current commit. Currently one would have to remove `--fail` from the repo's `args` configuration but that would let all warnings pass and would be besides the point.

## As an aside

* New method `score.mscx.update_metadata()` to facilitate (manual) updating of the key-value pairs.
* Comparison files come with the metadata key `compared_against=<commit hash>` when the comparison has been performed against a particular git revision.
* `"LATEST_VERSION"` is now accepted as argument to `git_revision` and resolves to the latest version tag (falling back to the current HEAD if the repo has no tags)